### PR TITLE
use postAsync or event to enable ExApp after its initialization

### DIFF
--- a/.github/workflows/tests-special.yml
+++ b/.github/workflows/tests-special.yml
@@ -117,7 +117,7 @@ jobs:
           php occ app_api:daemon:register manual_install "Manual Install" manual-install 0 0 0
           php occ app_api:app:register nc_py_api manual_install --json-info \
             "{\"appid\":\"$APP_ID\",\"name\":\"$APP_ID\",\"daemon_config_name\":\"manual_install\",\"version\":\"$APP_VERSION\",\"secret\":\"$APP_SECRET\",\"host\":\"localhost\",\"port\":$APP_PORT,\"scopes\":{\"required\":[\"SYSTEM\", \"FILES\", \"FILES_SHARING\"],\"optional\":[\"USER_INFO\", \"USER_STATUS\", \"NOTIFICATIONS\", \"WEATHER_STATUS\", \"TALK\"]},\"protocol\":\"http\",\"system_app\":1}" \
-            -e --force-scopes
+            --force-scopes
           kill -15 $(cat /tmp/_install.pid)
           timeout 3m tail --pid=$(cat /tmp/_install.pid) -f /dev/null
 

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -14,6 +14,8 @@ return [
 		['name' => 'ExAppsPage#enableApp', 'url' => '/apps/enable/{appId}', 'verb' => 'GET' , 'root' => ''],
 		['name' => 'ExAppsPage#enableApp', 'url' => '/apps/enable/{appId}', 'verb' => 'POST' , 'root' => ''],
 		['name' => 'ExAppsPage#getAppStatus', 'url' => '/apps/status/{appId}', 'verb' => 'GET' , 'root' => ''],
+		['name' => 'ExAppsPage#postAppProgressFinished', 'url' => '/apps/status/{appId}/init-finished', 'verb' => 'POST', 'root' => ''],
+		['name' => 'ExAppsPage#enableApps', 'url' => '/apps/enable', 'verb' => 'POST' , 'root' => ''],
 		['name' => 'ExAppsPage#enableApps', 'url' => '/apps/enable', 'verb' => 'POST' , 'root' => ''],
 		['name' => 'ExAppsPage#disableApp', 'url' => '/apps/disable/{appId}', 'verb' => 'GET' , 'root' => ''],
 		['name' => 'ExAppsPage#disableApps', 'url' => '/apps/disable', 'verb' => 'POST' , 'root' => ''],

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -6,6 +6,8 @@ namespace OCA\AppAPI\AppInfo;
 
 use OCA\AppAPI\Capabilities;
 use OCA\AppAPI\DavPlugin;
+use OCA\AppAPI\Event\ExAppInitializedEvent;
+use OCA\AppAPI\Listener\ExAppInitializedListener;
 use OCA\AppAPI\Listener\LoadFilesPluginListener;
 use OCA\AppAPI\Listener\SabrePluginAuthInitListener;
 use OCA\AppAPI\Listener\UserDeletedListener;
@@ -54,6 +56,7 @@ class Application extends App implements IBootstrap {
 		$context->registerMiddleware(AppAPIAuthMiddleware::class);
 		$context->registerEventListener(SabrePluginAuthInitEvent::class, SabrePluginAuthInitListener::class);
 		$context->registerEventListener(UserDeletedEvent::class, UserDeletedListener::class);
+		$context->registerEventListener(ExAppInitializedEvent::class, ExAppInitializedListener::class);
 		$context->registerNotifierService(ExAppNotifier::class);
 		$context->registerNotifierService(ExAppAdminNotifier::class);
 	}

--- a/lib/Controller/OCSApiController.php
+++ b/lib/Controller/OCSApiController.php
@@ -89,6 +89,7 @@ class OCSApiController extends OCSController {
 	/**
 	 * @PublicPage
 	 * @NoCSRFRequired
+	 * @NoAdminRequired
 	 *
 	 * Get ExApp status, that required during initialization step with progress information
 	 *
@@ -96,6 +97,7 @@ class OCSApiController extends OCSController {
 	 */
 	#[AppAPIAuth]
 	#[PublicPage]
+	#[NoAdminRequired]
 	#[NoCSRFRequired]
 	public function setAppProgress(string $appId, int $progress, string $error = ''): DataResponse {
 		$this->service->setAppInitProgress($appId, $progress, $error);

--- a/lib/Controller/OCSApiController.php
+++ b/lib/Controller/OCSApiController.php
@@ -100,6 +100,7 @@ class OCSApiController extends OCSController {
 	#[NoAdminRequired]
 	#[NoCSRFRequired]
 	public function setAppProgress(string $appId, int $progress, string $error = ''): DataResponse {
+		$this->logger->warning(sprintf('[AppAPI] Setting ExApp %s progress %s', $appId, $progress));
 		$this->service->setAppInitProgress($appId, $progress, $error);
 		return new DataResponse();
 	}

--- a/lib/Event/ExAppInitializedEvent.php
+++ b/lib/Event/ExAppInitializedEvent.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\AppAPI\Event;
+
+use OCP\EventDispatcher\Event;
+
+class ExAppInitializedEvent extends Event {
+	private string $appId;
+
+	public function __construct(?string $appId) {
+		parent::__construct();
+		if (isset($appId)) {
+			$this->appId = $appId;
+		}
+	}
+
+	public function setAppid(string $appId): void {
+		$this->appId = $appId;
+	}
+
+	public function getAppid(): string {
+		return $this->appId;
+	}
+}

--- a/lib/Listener/ExAppInitializedListener.php
+++ b/lib/Listener/ExAppInitializedListener.php
@@ -37,7 +37,6 @@ class ExAppInitializedListener implements IEventListener {
 			$attempts++;
 			$exApp = $this->service->getExApp($event->getAppid());
 			$status = json_decode($exApp->getStatus(), true);
-			$this->logger->warning('ExApp ' . $event->getAppid() . ' status: ' . json_encode($status) );
 			if (!isset($status['progress']) && !isset($status['error']) && $status['active']) {
 				$this->service->enableExApp($exApp);
 				return;

--- a/lib/Listener/ExAppInitializedListener.php
+++ b/lib/Listener/ExAppInitializedListener.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\AppAPI\Listener;
+
+use OCA\AppAPI\Event\ExAppInitializedEvent;
+use OCA\AppAPI\Service\AppAPIService;
+use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IEventListener;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Enabled ExApp after initialization finished
+ *
+ * @template-implements IEventListener<ExAppInitializedEvent>
+ */
+class ExAppInitializedListener implements IEventListener {
+	private LoggerInterface $logger;
+	private AppAPIService $service;
+
+	public function __construct(LoggerInterface $logger, AppAPIService $service) {
+		$this->logger = $logger;
+		$this->service = $service;
+	}
+
+	public function handle(Event $event): void {
+		if (!($event instanceof ExAppInitializedEvent)) {
+			return;
+		}
+
+		$attempts = 0;
+		$totalAttempts = 3;
+		$delay = 1;
+
+		while ($attempts < $totalAttempts) {
+			$attempts++;
+			$exApp = $this->service->getExApp($event->getAppid());
+			$status = json_decode($exApp->getStatus(), true);
+			$this->logger->warning('ExApp ' . $event->getAppid() . ' status: ' . json_encode($status) );
+			if (!isset($status['progress']) && !isset($status['error']) && $status['active']) {
+				$this->service->enableExApp($exApp);
+				return;
+			}
+			sleep($delay);
+		}
+
+		$this->logger->error(sprintf('Did not catch ExApp %s in initialized state to enable.', $event->getAppid()));
+	}
+}

--- a/lib/Listener/ExAppInitializedListener.php
+++ b/lib/Listener/ExAppInitializedListener.php
@@ -37,6 +37,7 @@ class ExAppInitializedListener implements IEventListener {
 			$attempts++;
 			$exApp = $this->service->getExApp($event->getAppid());
 			$status = json_decode($exApp->getStatus(), true);
+			$this->logger->warning('ExApp initialization attempt: ' . $attempts . ', status: ' . $exApp->getStatus());
 			if (!isset($status['progress']) && !isset($status['error']) && $status['active']) {
 				$this->service->enableExApp($exApp);
 				return;

--- a/lib/Service/AppAPIService.php
+++ b/lib/Service/AppAPIService.php
@@ -361,6 +361,11 @@ class AppAPIService {
 				$this->logger->warning('Sending async postAppProgressFinished');
 				$this->client->postAsync($this->url->getAbsoluteURL(sprintf('/index.php/apps/app_api/apps/status/%s/init-finished', $appId)), [
 					'json' => ['secret' => $exApp->getSecret()],
+					'options' => [
+						'nextcloud' => [
+							'allow_local_address' => true,
+						],
+					],
 				])->then(function (IResponse $response) {
 					$this->logger->warning('Then postAppProgressFinished: ' . $response->getStatusCode() . ', body: ' . $response->getBody());
 				})->wait();

--- a/tests/psalm-baseline.xml
+++ b/tests/psalm-baseline.xml
@@ -2,6 +2,7 @@
 <files psalm-version="5.15.0@5c774aca4746caf3d239d9c8cadb9f882ca29352">
   <file src="lib/AppInfo/Application.php">
     <InvalidArgument>
+      <code>ExAppInitializedListener::class</code>
       <code>LoadFilesPluginListener::class</code>
       <code>SabrePluginAuthInitListener::class</code>
       <code>UserDeletedListener::class</code>


### PR DESCRIPTION
Using asynchronous event after ExApp finished initialization to enable it.

- [ ] Figure out the way to make it work with single process webserver (like in CI tests built-in PHP webserver), because of asynchronous operations used.