### PR TITLE
show error note if default daemon is not accessible

### DIFF
--- a/lib/DeployActions/AIODockerActions.php
+++ b/lib/DeployActions/AIODockerActions.php
@@ -41,9 +41,12 @@ class AIODockerActions {
 	 * @return DaemonConfig|null
 	 */
 	public function registerAIODaemonConfig(): ?DaemonConfig {
-		$daemonConfig = $this->daemonConfigService->getDaemonConfigByName(self::AIO_DAEMON_CONFIG_NAME);
-		if ($daemonConfig !== null) {
-			return null;
+		$defaultDaemonConfig = $this->config->getAppValue(Application::APP_ID, 'default_daemon_config', '');
+		if ($defaultDaemonConfig !== '') {
+			$daemonConfig = $this->daemonConfigService->getDaemonConfigByName(self::AIO_DAEMON_CONFIG_NAME);
+			if ($daemonConfig !== null) {
+				return null;
+			}
 		}
 
 		$deployConfig = [

--- a/lib/DeployActions/DockerActions.php
+++ b/lib/DeployActions/DockerActions.php
@@ -574,14 +574,6 @@ class DockerActions implements IDeployActions {
 		];
 	}
 
-	public function isDockerSocketAvailable(): bool {
-		$dockerSocket = '/var/run/docker.sock';
-		if (file_exists($dockerSocket) && is_readable($dockerSocket) && is_writable($dockerSocket)) {
-			return true;
-		}
-		return false;
-	}
-
 	/**
 	 * Build ExApp container name (prefix + appid)
 	 *
@@ -599,9 +591,11 @@ class DockerActions implements IDeployActions {
 
 	public function registerDefaultDaemonConfig(): ?DaemonConfig {
 		$defaultDaemonConfig = $this->config->getAppValue(Application::APP_ID, 'default_daemon_config', '');
-		$daemonConfig = $this->daemonConfigService->getDaemonConfigByName($defaultDaemonConfig);
-		if ($daemonConfig !== null) {
-			return $daemonConfig;
+		if ($defaultDaemonConfig !== '') {
+			$daemonConfig = $this->daemonConfigService->getDaemonConfigByName($defaultDaemonConfig);
+			if ($daemonConfig !== null) {
+				return $daemonConfig;
+			}
 		}
 
 		$deployConfig = [

--- a/lib/Service/DaemonConfigService.php
+++ b/lib/Service/DaemonConfigService.php
@@ -114,4 +114,8 @@ class DaemonConfigService {
 			return null;
 		}
 	}
+
+	public function defaultDaemonConfigAccessible() {
+
+	}
 }

--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -28,9 +28,8 @@
 			<NcNoteCard type="warning">
 				<p>{{ t('app_api', 'Currently only Docker Daemon is supported.') }}</p>
 			</NcNoteCard>
-			<NcNoteCard v-if="!state?.docker_socket_accessible" type="error">
-				<p>{{ t('app_api', 'Default Docker socket (/var/run/docker.sock) is not accessible.') }}</p>
-				<p>{{ t('app_api', 'Please, make sure that docker is installed on server and webserver user have enough rights to it.') }}</p>
+			<NcNoteCard v-if="state.default_daemon_config !== '' && !state?.daemon_config_accessible" type="error">
+				<p>{{ t('app_api', 'Default Deploy Daemon is not accessible. Please verify its configuration') }}</p>
 			</NcNoteCard>
 			<DaemonConfigList :daemons.sync="daemons" :default-daemon.sync="default_daemon_config" :save-options="saveOptions" />
 		</NcSettingsSection>
@@ -65,7 +64,7 @@ export default {
 	},
 	data() {
 		return {
-			state: loadState('app_api', 'admin-config'),
+			state: loadState('app_api', 'admin-initial-data'),
 			daemons: [],
 			default_daemon_config: '',
 			docker_socket_accessible: false,
@@ -81,7 +80,7 @@ export default {
 	},
 	methods: {
 		loadInitialState() {
-			const state = loadState('app_api', 'admin-config')
+			const state = loadState('app_api', 'admin-initial-data')
 			this.daemons = state.daemons
 			this.default_daemon_config = state.default_daemon_config
 			this.docker_socket_accessible = state.docker_socket_accessible


### PR DESCRIPTION
Resolves: #100 

Check only default daemon connection the same as in ExApps management page and show error note in admin settings.