### PR TITLE
add some security notes for admins

### DIFF
--- a/docs/DeployConfigurations.rst
+++ b/docs/DeployConfigurations.rst
@@ -14,7 +14,7 @@ Orchestrates the deployment of applications as Docker containers.
 .. warning::
 
 	The administrator is responsible for the security actions taken to configure the Docker daemon connected to Nextcloud.
-	For example, look at the Docker Socket Proxy protected by strict rules without root access (`like in AIO <#nextcloud-in-docker-aio-all-in-one>`_)
+	For example, look at the Docker Socket Proxy protected by strict rules (`like in AIO <#nextcloud-in-docker-aio-all-in-one>`_)
 
 There are several Docker Daemon Deploy configurations (example schemes):
 

--- a/docs/DeployConfigurations.rst
+++ b/docs/DeployConfigurations.rst
@@ -13,8 +13,8 @@ Provides the deployment of applications as Docker containers.
 
 .. warning::
 
-	Administrator is responsible for security actions taken to configure Docker daemon connected to Nextcloud.
-	As for example look at the Docker Socket Proxy secured with strict rules without root access (`like in AIO <#nextcloud-in-docker-aio-all-in-one>`_)
+	The administrator is responsible for the security actions taken to configure the Docker daemon connected to Nextcloud.
+	For example, look at the Docker Socket Proxy protected by strict rules without root access (`like in AIO <#nextcloud-in-docker-aio-all-in-one>`_)
 
 There are several Docker Daemon Deploy configurations (example schemes):
 
@@ -227,13 +227,13 @@ AppAPI will automatically create default default DaemonConfig to use AIO Docker 
 
 .. note::
 
-	Default DaemonConfig will be created only if there is no default DaemonConfig already registered.
+	Default DaemonConfig will be created only if the default DaemonConfig is not already registered.
 
 
 Default AIO Deploy Daemon
 *************************
 
-Nextcloud AIO has specifically created Docker Socket Proxy container to be used as Deploy Daemon in AppAPI.
+Nextcloud AIO has a specifically created Docker Socket Proxy container to be used as the Deploy Daemon in AppAPI.
 It has `fixed parameters <https://github.com/cloud-py-api/app_api/blob/main/lib/DeployActions/AIODockerActions.php#L52-L74)>`_:
 
 * Name: ``docker_aio``
@@ -248,4 +248,4 @@ It has `fixed parameters <https://github.com/cloud-py-api/app_api/blob/main/lib/
 Docker Socket Proxy security
 ****************************
 
-AIO Docker Socket Proxy has strictly limited access to Docker APIs described in `HAProxy configuration <https://github.com/nextcloud/all-in-one/blob/main/Containers/docker-socket-proxy/haproxy.cfg>`_.
+AIO Docker Socket Proxy has strictly limited access to the Docker APIs described in `HAProxy configuration <https://github.com/nextcloud/all-in-one/blob/main/Containers/docker-socket-proxy/haproxy.cfg>`_.

--- a/docs/DeployConfigurations.rst
+++ b/docs/DeployConfigurations.rst
@@ -11,7 +11,12 @@ Docker Deploy Daemon
 
 Provides the deployment of applications as Docker containers.
 
-There are several Docker Daemon Deploy configurations:
+.. warning::
+
+	Administrator is responsible for security actions taken to configure Docker daemon connected to Nextcloud.
+	As for example look at the Docker Socket Proxy secured with strict rules without root access (`like in AIO <#nextcloud-in-docker-aio-all-in-one>`_)
+
+There are several Docker Daemon Deploy configurations (example schemes):
 
 	* Nextcloud and Docker on the **same host** (via socket or port)
 	* Nextcloud on the host and Docker on a **remote** host (via port)
@@ -219,3 +224,28 @@ In case of AppAPI is in Docker AIO setup (installed in Nextcloud container).
 		class ExApp3 python
 
 AppAPI will automatically create default default DaemonConfig to use AIO Docker Socket Proxy as orchestrator to create ExApp containers.
+
+.. note::
+
+	Default DaemonConfig will be created only if there is no default DaemonConfig already registered.
+
+
+Default AIO Deploy Daemon
+*************************
+
+Nextcloud AIO has specifically created Docker Socket Proxy container to be used as Deploy Daemon in AppAPI.
+It has `fixed parameters <https://github.com/cloud-py-api/app_api/blob/main/lib/DeployActions/AIODockerActions.php#L52-L74)>`_:
+
+* Name: ``docker_aio``
+* Display name: ``AIO Docker Socket Proxy``
+* Accepts Deploy ID: ``docker-install``
+* Protocol: ``http``
+* Host: ``nextcloud-aio-docker-socket-proxy:2375``
+* GPUs support: If enabled during AIO setup (``NEXTCLOUD_ENABLE_DRI_DEVICE=true``)
+* Network: ``nextcloud-aio``
+* Nextcloud URL (passed to ExApps): ``https://$NC_DOMAIN``
+
+Docker Socket Proxy security
+****************************
+
+AIO Docker Socket Proxy has strictly limited access to Docker APIs described in `HAProxy configuration <https://github.com/nextcloud/all-in-one/blob/main/Containers/docker-socket-proxy/haproxy.cfg>`_.

--- a/docs/resources/css/styles.css
+++ b/docs/resources/css/styles.css
@@ -7,6 +7,8 @@ th p {
     margin-bottom: 0;
 }
 
-.wy-nav-content {
-	max-width: 80% !important;
+@media screen and (min-width: 1100px) {
+	.wy-nav-content {
+		max-width: 80% !important;
+	}
 }


### PR DESCRIPTION
Related to: #98 

Add security warning about Deploy daemon configuration and security

Removed Docker in Docker scheme as it is not recommended

Added to the examples recommended schemes with docker-socket-proxy

- [ ] Merge after suggested docker-socket-proxy container is available to use for other than AIO configurations.