### PR TITLE
Notes about possibility to use other OCS APIs with AppAPI

### DIFF
--- a/docs/tech_details/api/index.rst
+++ b/docs/tech_details/api/index.rst
@@ -17,3 +17,4 @@ AppAPI Nextcloud APIs
 	fileactionsmenu
 	notifications
 	talkbots
+	other_ocs

--- a/docs/tech_details/api/other_ocs.rst
+++ b/docs/tech_details/api/other_ocs.rst
@@ -1,0 +1,13 @@
+Other OCS APIs
+==============
+
+With AppAPI authentication it is possible for ExApps to use any other OCS APIs, that doesn't require OCP implementation:
+
+1. Calendar
+2. Contacts
+3. File System & Tags
+4. Shares
+5. Notifications
+6. Users & Groups
+7. User & Weather status
+8. Etc.

--- a/docs/tech_details/api/other_ocs.rst
+++ b/docs/tech_details/api/other_ocs.rst
@@ -3,6 +3,11 @@ Other OCS APIs
 
 With AppAPI authentication it is possible for ExApps to use any other OCS APIs, that doesn't require OCP implementation:
 
+.. note::
+
+	To access these APIs they have to be supported by AppAPI (see :ref:`api_scopes`),
+	and ExApp have to require granted access (in ``info.xml``) to them accordingly.
+
 1. Calendar
 2. Contacts
 3. File System & Tags
@@ -10,4 +15,6 @@ With AppAPI authentication it is possible for ExApps to use any other OCS APIs, 
 5. Notifications
 6. Users & Groups
 7. User & Weather status
-8. Etc.
+8. Activities
+9. Notes
+10. Etc.


### PR DESCRIPTION
Added missing notes that it is possible to use other supported OCS APIs (mainly oriented for clients) for ExApps as we have separate authentication for that.

