### PR TITLE
fixed UI error when default_daemon_config config missing

### DIFF
--- a/lib/Controller/ExAppsPageController.php
+++ b/lib/Controller/ExAppsPageController.php
@@ -105,11 +105,13 @@ class ExAppsPageController extends Controller {
 
 		if ($defaultDaemonConfigName !== '') {
 			$daemonConfig = $this->daemonConfigService->getDaemonConfigByName($defaultDaemonConfigName);
-			$this->dockerActions->initGuzzleClient($daemonConfig);
-			$daemonConfigAccessible = $this->dockerActions->ping($this->dockerActions->buildDockerUrl($daemonConfig));
-			$appInitialData['daemon_config_accessible'] = $daemonConfigAccessible;
-			if (!$daemonConfigAccessible) {
-				$this->logger->error(sprintf('Deploy daemon "%s" is not accessible by Nextcloud. Please verify its configuration', $daemonConfig->getName()));
+			if ($daemonConfig !== null) {
+				$this->dockerActions->initGuzzleClient($daemonConfig);
+				$daemonConfigAccessible = $this->dockerActions->ping($this->dockerActions->buildDockerUrl($daemonConfig));
+				$appInitialData['daemon_config_accessible'] = $daemonConfigAccessible;
+				if (!$daemonConfigAccessible) {
+					$this->logger->error(sprintf('Deploy daemon "%s" is not accessible by Nextcloud. Please verify its configuration', $daemonConfig->getName()));
+				}
 			}
 		}
 

--- a/lib/Settings/Admin.php
+++ b/lib/Settings/Admin.php
@@ -72,11 +72,13 @@ class Admin implements ISettings {
 		$defaultDaemonConfigName = $this->config->getAppValue(Application::APP_ID, 'default_daemon_config', '');
 		if ($defaultDaemonConfigName !== '') {
 			$daemonConfig = $this->daemonConfigService->getDaemonConfigByName($defaultDaemonConfigName);
-			$this->dockerActions->initGuzzleClient($daemonConfig);
-			$daemonConfigAccessible = $this->dockerActions->ping($this->dockerActions->buildDockerUrl($daemonConfig));
-			$adminInitialData['daemon_config_accessible'] = $daemonConfigAccessible;
-			if (!$daemonConfigAccessible) {
-				$this->logger->error(sprintf('Deploy daemon "%s" is not accessible by Nextcloud. Please verify its configuration', $daemonConfig->getName()));
+			if ($daemonConfig !== null) {
+				$this->dockerActions->initGuzzleClient($daemonConfig);
+				$daemonConfigAccessible = $this->dockerActions->ping($this->dockerActions->buildDockerUrl($daemonConfig));
+				$adminInitialData['daemon_config_accessible'] = $daemonConfigAccessible;
+				if (!$daemonConfigAccessible) {
+					$this->logger->error(sprintf('Deploy daemon "%s" is not accessible by Nextcloud. Please verify its configuration', $daemonConfig->getName()));
+				}
 			}
 		}
 


### PR DESCRIPTION
When a daemon has been selected by default and then for some reason its configuration is missing from the DB, the AppAPI application becomes unusable from the UI.

_I came across this locally today._