### PR TITLE
change field to type 'TEXT' (no migration)

### DIFF
--- a/lib/Migration/Version1000Date202305221555.php
+++ b/lib/Migration/Version1000Date202305221555.php
@@ -37,7 +37,7 @@ class Version1000Date202305221555 extends SimpleMigrationStep {
 				'notnull' => true,
 				'length' => 64
 			]);
-			$table->addColumn('configvalue', Types::STRING, [
+			$table->addColumn('configvalue', Types::TEXT, [
 				'notnull' => false,
 			]);
 			$table->addColumn('sensitive', Types::SMALLINT, [
@@ -167,7 +167,7 @@ class Version1000Date202305221555 extends SimpleMigrationStep {
 				'notnull' => true,
 				'length' => 64,
 			]);
-			$table->addColumn('configvalue', Types::STRING, [
+			$table->addColumn('configvalue', Types::TEXT, [
 				'notnull' => false,
 			]);
 


### PR DESCRIPTION
Resolves: https://github.com/cloud-py-api/app_api/issues/116


For some reason it was not possible to do this by migration(I tried but got `tinytext` instead of `text`), but this is not particularly important, since this is more of a change for the future.


