### PR TITLE
occ app_api:app:unregister rework

### DIFF
--- a/.github/workflows/tests-deploy.yml
+++ b/.github/workflows/tests-deploy.yml
@@ -50,13 +50,6 @@ jobs:
           repository: nextcloud/server
           ref: ${{ matrix.server-version }}
 
-      - name: Checkout Notifications
-        uses: actions/checkout@v3
-        with:
-          repository: nextcloud/notifications
-          ref: ${{ matrix.server-version }}
-          path: apps/notifications
-
       - name: Checkout AppAPI
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
         with:
@@ -93,7 +86,6 @@ jobs:
             --admin-user admin --admin-pass admin
           ./occ config:system:set loglevel --value=0 --type=integer
           ./occ config:system:set debug --value=true --type=boolean
-          ./occ app:enable notifications
           ./occ app:enable --force ${{ env.APP_NAME }}
 
       - name: Test deploy

--- a/.github/workflows/tests-deploy.yml
+++ b/.github/workflows/tests-deploy.yml
@@ -62,6 +62,8 @@ jobs:
           extensions: bz2, ctype, curl, dom, fileinfo, gd, iconv, intl, json, libxml, mbstring, openssl, pcntl, posix, session, simplexml, xmlreader, xmlwriter, zip, zlib, pgsql, pdo_pgsql
           coverage: none
           ini-file: development
+          ini-values:
+            apc.enabled=on, apc.enable_cli=on, disable_functions=
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/tests-deploy.yml
+++ b/.github/workflows/tests-deploy.yml
@@ -98,22 +98,25 @@ jobs:
             --info-xml https://raw.githubusercontent.com/cloud-py-api/nc_py_api/main/examples/as_app/skeleton/appinfo/info.xml
           ./occ app_api:app:enable skeleton
           ./occ app_api:app:disable skeleton
-          ./occ app_api:app:unregister skeleton
-          ./occ app_api:daemon:unregister docker_local_sock
 
       - name: Check logs
         run: |
           grep -q 'Hello from skeleton :)' data/nextcloud.log || error
           grep -q 'Bye bye from skeleton :(' data/nextcloud.log || error
 
-      - name: Test OCC commands(docker)
-        run: python3 apps/${{ env.APP_NAME }}/tests/test_occ_commands_docker.py
-
       - name: Save container ingo & logs
         if: always()
         run: |
           docker inspect nc_app_skeleton | json_pp > container.json
           docker logs nc_app_skeleton > container.log 2>&1
+
+      - name: Unregister Skeleton & Daemon
+        run: |
+          ./occ app_api:app:unregister skeleton
+          ./occ app_api:daemon:unregister docker_local_sock
+
+      - name: Test OCC commands(docker)
+        run: python3 apps/${{ env.APP_NAME }}/tests/test_occ_commands_docker.py
 
       - name: Upload Container info
         if: always()
@@ -171,8 +174,6 @@ jobs:
             --info-xml https://raw.githubusercontent.com/cloud-py-api/nc_py_api/main/examples/as_app/skeleton/appinfo/info.xml
           docker exec nextcloud sudo -u www-data php occ app_api:app:enable skeleton
           docker exec nextcloud sudo -u www-data php occ app_api:app:disable skeleton
-          docker exec nextcloud sudo -u www-data php occ app_api:app:unregister skeleton --silent
-          docker exec nextcloud sudo -u www-data php occ app_api:daemon:unregister docker_local_sock
 
       - name: Copy NC log to host
         run: docker cp nextcloud:/var/www/html/data/nextcloud.log nextcloud.log
@@ -187,6 +188,11 @@ jobs:
         run: |
           docker inspect nc_app_skeleton | json_pp > container.json
           docker logs nc_app_skeleton > container.log 2>&1
+
+      - name: Unregister Skeleton & Daemon
+        run: |
+          docker exec nextcloud sudo -u www-data php occ app_api:app:unregister skeleton
+          docker exec nextcloud sudo -u www-data php occ app_api:daemon:unregister docker_local_sock
 
       - name: Upload Container info
         if: always()
@@ -249,8 +255,6 @@ jobs:
             --info-xml https://raw.githubusercontent.com/cloud-py-api/nc_py_api/main/examples/as_app/skeleton/appinfo/info.xml
           docker exec nextcloud sudo -u www-data php occ app_api:app:enable skeleton
           docker exec nextcloud sudo -u www-data php occ app_api:app:disable skeleton
-          docker exec nextcloud sudo -u www-data php occ app_api:app:unregister skeleton --silent
-          docker exec nextcloud sudo -u www-data php occ app_api:daemon:unregister docker_by_port
 
       - name: Copy NC log to host
         run: docker cp nextcloud:/var/www/html/data/nextcloud.log nextcloud.log
@@ -265,6 +269,11 @@ jobs:
         run: |
           docker inspect nc_app_skeleton | json_pp > container.json
           docker logs nc_app_skeleton > container.log 2>&1
+
+      - name: Unregister Skeleton & Daemon
+        run: |
+          docker exec nextcloud sudo -u www-data php occ app_api:app:unregister skeleton
+          docker exec nextcloud sudo -u www-data php occ app_api:daemon:unregister docker_by_port
 
       - name: Upload Container info
         if: always()
@@ -326,8 +335,6 @@ jobs:
             --info-xml https://raw.githubusercontent.com/cloud-py-api/nc_py_api/main/examples/as_app/skeleton/appinfo/info.xml
           docker exec nextcloud sudo -u www-data php occ app_api:app:enable skeleton
           docker exec nextcloud sudo -u www-data php occ app_api:app:disable skeleton
-          docker exec nextcloud sudo -u www-data php occ app_api:app:unregister skeleton --silent
-          docker exec nextcloud sudo -u www-data php occ app_api:daemon:unregister docker_by_port
 
       - name: Copy NC log to host
         run: docker cp nextcloud:/var/www/html/data/nextcloud.log nextcloud.log
@@ -342,6 +349,11 @@ jobs:
         run: |
           docker inspect nc_app_skeleton | json_pp > container.json
           docker logs nc_app_skeleton > container.log 2>&1
+
+      - name: Unregister Skeleton & Daemon
+        run: |
+          docker exec nextcloud sudo -u www-data php occ app_api:app:unregister skeleton
+          docker exec nextcloud sudo -u www-data php occ app_api:daemon:unregister docker_by_port
 
       - name: Upload Container info
         if: always()
@@ -468,22 +480,25 @@ jobs:
             --info-xml https://raw.githubusercontent.com/cloud-py-api/nc_py_api/main/examples/as_app/skeleton/appinfo/info.xml
           ./occ app_api:app:enable skeleton
           ./occ app_api:app:disable skeleton
-          ./occ app_api:app:unregister skeleton --silent
-          ./occ app_api:daemon:unregister docker_local_sock
 
       - name: Check logs
         run: |
           grep -q 'Hello from skeleton :)' data/nextcloud.log || error
           grep -q 'Bye bye from skeleton :(' data/nextcloud.log || error
 
-      - name: Test OCC commands(docker)
-        run: python3 apps/${{ env.APP_NAME }}/tests/test_occ_commands_docker.py
-
       - name: Save container ingo & logs
         if: always()
         run: |
           docker inspect nc_app_skeleton | json_pp > container.json
           docker logs nc_app_skeleton > container.log 2>&1
+
+      - name: Unregister Skeleton & Daemon
+        run: |
+          ./occ app_api:app:unregister skeleton
+          ./occ app_api:daemon:unregister docker_local_sock
+
+      - name: Test OCC commands(docker)
+        run: python3 apps/${{ env.APP_NAME }}/tests/test_occ_commands_docker.py
 
       - name: Check redis keys
         run: |

--- a/.github/workflows/tests-deploy.yml
+++ b/.github/workflows/tests-deploy.yml
@@ -98,13 +98,16 @@ jobs:
             --info-xml https://raw.githubusercontent.com/cloud-py-api/nc_py_api/main/examples/as_app/skeleton/appinfo/info.xml
           ./occ app_api:app:enable skeleton
           ./occ app_api:app:disable skeleton
-          ./occ app_api:app:unregister skeleton --silent
+          ./occ app_api:app:unregister skeleton
           ./occ app_api:daemon:unregister docker_local_sock
 
       - name: Check logs
         run: |
           grep -q 'Hello from skeleton :)' data/nextcloud.log || error
           grep -q 'Bye bye from skeleton :(' data/nextcloud.log || error
+
+      - name: Test OCC commands(docker)
+        run: python3 apps/${{ env.APP_NAME }}/tests/test_occ_commands_docker.py
 
       - name: Save container ingo & logs
         if: always()
@@ -472,6 +475,9 @@ jobs:
         run: |
           grep -q 'Hello from skeleton :)' data/nextcloud.log || error
           grep -q 'Bye bye from skeleton :(' data/nextcloud.log || error
+
+      - name: Test OCC commands(docker)
+        run: python3 apps/${{ env.APP_NAME }}/tests/test_occ_commands_docker.py
 
       - name: Save container ingo & logs
         if: always()

--- a/.github/workflows/tests-special.yml
+++ b/.github/workflows/tests-special.yml
@@ -51,6 +51,13 @@ jobs:
           repository: nextcloud/server
           ref: 'stable27'
 
+      - name: Checkout Notifications
+        uses: actions/checkout@v3
+        with:
+          repository: nextcloud/notifications
+          ref: ${{ matrix.server-version }}
+          path: apps/notifications
+
       - name: Checkout AppAPI
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
         with:
@@ -85,6 +92,7 @@ jobs:
           ./occ maintenance:install --verbose --database=pgsql --database-name=nextcloud --database-host=127.0.0.1 \
             --database-port=$DB_PORT --database-user=root --database-pass=rootpassword \
             --admin-user admin --admin-pass admin
+          ./occ app:enable notifications
           ./occ app:enable --force ${{ env.APP_NAME }}
 
       - name: Run Nextcloud

--- a/.github/workflows/tests-special.yml
+++ b/.github/workflows/tests-special.yml
@@ -13,16 +13,17 @@ concurrency:
   group: tests-special-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
+env:
+  NEXTCLOUD_URL: "http://localhost:8080/"
+  APP_ID: "nc_py_api"
+  APP_PORT: 9009
+  APP_VERSION: "1.0.0"
+  APP_SECRET: "tC6vkwPhcppjMykD1r0n9NlI95uJMBYjs5blpIcA1PAdoPDmc5qoAjaBAkyocZ6E"
+
 jobs:
   app-version-higher:
     runs-on: ubuntu-22.04
     name: ExApp version higher
-    env:
-      NEXTCLOUD_URL: "http://localhost:8080/"
-      APP_ID: "nc_py_api"
-      APP_PORT: 9009
-      APP_VERSION: "1.0.0"
-      APP_SECRET: "tC6vkwPhcppjMykD1r0n9NlI95uJMBYjs5blpIcA1PAdoPDmc5qoAjaBAkyocZ6E"
 
     services:
       postgres:
@@ -49,13 +50,6 @@ jobs:
           submodules: true
           repository: nextcloud/server
           ref: 'stable27'
-
-      - name: Checkout Notifications
-        uses: actions/checkout@v3
-        with:
-          repository: nextcloud/notifications
-          ref: ${{ matrix.server-version }}
-          path: apps/notifications
 
       - name: Checkout AppAPI
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
@@ -91,7 +85,6 @@ jobs:
           ./occ maintenance:install --verbose --database=pgsql --database-name=nextcloud --database-host=127.0.0.1 \
             --database-port=$DB_PORT --database-user=root --database-pass=rootpassword \
             --admin-user admin --admin-pass admin
-          ./occ app:enable notifications
           ./occ app:enable --force ${{ env.APP_NAME }}
 
       - name: Run Nextcloud

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,6 +13,14 @@ concurrency:
   group: tests-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
+env:
+  NEXTCLOUD_URL: "http://localhost:8080/"
+  APP_ID: "nc_py_api"
+  APP_PORT: 9009
+  APP_VERSION: "1.0.0"
+  APP_SECRET: "tC6vkwPhcppjMykD1r0n9NlI95uJMBYjs5blpIcA1PAdoPDmc5qoAjaBAkyocZ6E"
+  SKIP_NC_CLIENT_TESTS: 1
+
 jobs:
   nc-py-api-pgsql:
     runs-on: ubuntu-22.04
@@ -27,13 +35,6 @@ jobs:
             php-version: "8.2"
           - server-version: "master"
             php-version: "8.3"
-    env:
-      NEXTCLOUD_URL: "http://localhost:8080/"
-      APP_ID: "nc_py_api"
-      APP_PORT: 9009
-      APP_VERSION: "1.0.0"
-      APP_SECRET: "tC6vkwPhcppjMykD1r0n9NlI95uJMBYjs5blpIcA1PAdoPDmc5qoAjaBAkyocZ6E"
-      SKIP_NC_CLIENT_TESTS: 1
 
     services:
       postgres:
@@ -144,14 +145,6 @@ jobs:
   nc-py-api-mysql:
     runs-on: ubuntu-22.04
     name: NC_Py_API • stable27 • 8.1 • MySQL
-
-    env:
-      NEXTCLOUD_URL: "http://localhost:8080/"
-      APP_ID: "nc_py_api"
-      APP_PORT: 9009
-      APP_VERSION: "1.0.0"
-      APP_SECRET: "tC6vkwPhcppjMykD1r0n9NlI95uJMBYjs5blpIcA1PAdoPDmc5qoAjaBAkyocZ6E"
-      SKIP_NC_CLIENT_TESTS: 1
 
     services:
       mysql:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [1.3.0 - 2023-12-0x]
+
+### Changed
+
+- Reworked: `app_api:app:unregister` occ cli command, make it much robust. #127
+
 ## [1.2.2 - 2023-11-13]
 
 ### Fixed

--- a/composer.json
+++ b/composer.json
@@ -48,5 +48,8 @@
 		"psr-4": {
 			"OCP\\": "vendor/nextcloud/ocp/OCP"
 		}
-	}
+	},
+  "require": {
+    "ext-simplexml": "*"
+  }
 }

--- a/docs/ManagingExternalApplications.rst
+++ b/docs/ManagingExternalApplications.rst
@@ -65,10 +65,10 @@ Options
 Unregister
 ----------
 
-Command: ``app_api:app:unregister [--silent] [--rm-container] [--rm-data] [--] <appid>``
+Command: ``app_api:app:unregister [--keep-data] [--force] [--silent] [--] <appid>``
 
 To remove an ExApp you can use the unregister command.
-There are additional options to remove the ExApp container and persistent storage (data volume).
+There are additional options to keep the ExApp persistent storage (data volume).
 
 Arguments
 *********
@@ -78,9 +78,9 @@ Arguments
 Options
 *******
 
-    * ``--silent`` *[optional]* - do not disable ExApp before unregister
-    * ``--rm-container`` *[optional]* - remove ExApp container
-    * ``--rm-data`` *[optional]* - remove ExApp persistent storage (data volume)
+    * ``--keep-data`` *[optional]* - keep ExApp persistent storage (data volume)
+	* ``--force`` *[optional]* - continue removal even if some error occurs.
+	* ``--silent`` *[optional]* - print a minimum of information, display only some errors, if any.
 
 Update
 ------

--- a/lib/Service/AppAPIService.php
+++ b/lib/Service/AppAPIService.php
@@ -221,9 +221,10 @@ class AppAPIService {
 					$this->logger->error(sprintf('Failed to disable ExApp %s. Error: %s', $exApp->getAppid(), $response['error']));
 				}
 			} elseif (isset($exAppDisabled['error'])) {
-				$this->logger->error(sprintf('Failed to enable ExApp %s. Error: %s', $exApp->getAppid(), $exAppDisabled['error']));
+				$this->logger->error(sprintf('Failed to disable ExApp %s. Error: %s', $exApp->getAppid(), $exAppDisabled['error']));
 			}
 			if ($this->exAppMapper->updateExAppEnabled($exApp->getAppid(), false) !== 1) {
+				$this->logger->error(sprintf('Error updating state of ExApp %s.', $exApp->getAppid()));
 				return false;
 			}
 			$this->updateExAppLastCheckTime($exApp);

--- a/tests/test_occ_commands_docker.py
+++ b/tests/test_occ_commands_docker.py
@@ -38,12 +38,12 @@ if __name__ == "__main__":
     assert not r.stderr.decode("UTF-8")
     assert not r.stdout.decode("UTF-8")
     # without "--silent" it should fail, as there are not such ExApp
-    r = run("php occ app_api:app:unregister skeleton".split(), stdout=PIPE, stderr=PIPE)
+    r = run("php occ app_api:app:unregister skeleton".split(), stdout=PIPE)
     assert r.returncode
-    assert r.stderr.decode("UTF-8")
+    assert r.stdout.decode("UTF-8")
     # testing if "--keep-data" works.
     deploy_register()
-    r = run("php occ app_api:app:unregister skeleton --keep-data".split(), stdout=PIPE, stderr=PIPE, check=True)
+    r = run("php occ app_api:app:unregister skeleton --keep-data".split(), stdout=PIPE, check=True)
     assert r.stdout.decode("UTF-8")
     run("docker volume inspect nc_app_skeleton_data".split(), check=True)
     # test if volume will be removed without "--keep-data"

--- a/tests/test_occ_commands_docker.py
+++ b/tests/test_occ_commands_docker.py
@@ -36,15 +36,16 @@ if __name__ == "__main__":
     # silent should not fail, as there are not such ExApp
     r = run("php occ app_api:app:unregister skeleton --silent".split(), stdout=PIPE, stderr=PIPE, check=True)
     assert not r.stderr.decode("UTF-8")
-    assert not r.stdout.decode("UTF-8")
+    r_output = r.stdout.decode("UTF-8")
+    assert not r_output, f"Output should be empty: {r_output}"
     # without "--silent" it should fail, as there are not such ExApp
     r = run("php occ app_api:app:unregister skeleton".split(), stdout=PIPE)
     assert r.returncode
-    assert r.stdout.decode("UTF-8")
+    assert r.stdout.decode("UTF-8"), "Output should be non empty"
     # testing if "--keep-data" works.
     deploy_register()
     r = run("php occ app_api:app:unregister skeleton --keep-data".split(), stdout=PIPE, check=True)
-    assert r.stdout.decode("UTF-8")
+    assert r.stdout.decode("UTF-8"), "Output should be non empty"
     run("docker volume inspect nc_app_skeleton_data".split(), check=True)
     # test if volume will be removed without "--keep-data"
     deploy_register()

--- a/tests/test_occ_commands_docker.py
+++ b/tests/test_occ_commands_docker.py
@@ -53,7 +53,9 @@ if __name__ == "__main__":
     assert r.returncode
     # test "--force" option
     deploy_register()
-    run("docker container stop nc_app_skeleton".split(), check=True)
+    run("docker container rm --force nc_app_skeleton".split(), check=True)
     r = run("php occ app_api:app:unregister skeleton".split())
+    assert r.returncode
+    r = run("php occ app_api:app:unregister skeleton --silent".split())
     assert r.returncode
     run("php occ app_api:app:unregister skeleton --force".split(), check=True)

--- a/tests/test_occ_commands_docker.py
+++ b/tests/test_occ_commands_docker.py
@@ -1,0 +1,59 @@
+from subprocess import run, DEVNULL, PIPE
+
+
+SKELETON_XML_URL = (
+    "https://raw.githubusercontent.com/cloud-py-api/nc_py_api/main/examples/as_app/skeleton/appinfo/info.xml"
+)
+
+
+def register_daemon():
+    run(
+        "php occ app_api:daemon:register docker_local_sock "
+        "Docker docker-install unix-socket /var/run/docker.sock http://127.0.0.1:8080/index.php".split(),
+        stderr=DEVNULL,
+        stdout=DEVNULL,
+        check=True,
+    )
+
+
+def deploy_register():
+    run(
+        f"php occ app_api:app:deploy skeleton docker_local_sock --info-xml {SKELETON_XML_URL}".split(),
+        stderr=DEVNULL,
+        stdout=DEVNULL,
+        check=True,
+    )
+    run(
+        f"php occ app_api:app:register skeleton docker_local_sock --info-xml {SKELETON_XML_URL}".split(),
+        stderr=DEVNULL,
+        stdout=DEVNULL,
+        check=True,
+    )
+
+
+if __name__ == "__main__":
+    register_daemon()
+    # silent should not fail, as there are not such ExApp
+    r = run("php occ app_api:app:unregister skeleton --silent".split(), stdout=PIPE, stderr=PIPE, check=True)
+    assert not r.stderr.decode("UTF-8")
+    assert not r.stdout.decode("UTF-8")
+    # without "--silent" it should fail, as there are not such ExApp
+    r = run("php occ app_api:app:unregister skeleton".split(), stdout=PIPE, stderr=PIPE)
+    assert r.returncode
+    assert r.stderr.decode("UTF-8")
+    # testing if "--keep-data" works.
+    deploy_register()
+    r = run("php occ app_api:app:unregister skeleton --keep-data".split(), stdout=PIPE, stderr=PIPE, check=True)
+    assert r.stdout.decode("UTF-8")
+    run("docker volume inspect nc_app_skeleton_data".split(), check=True)
+    # test if volume will be removed without "--keep-data"
+    deploy_register()
+    run("php occ app_api:app:unregister skeleton".split(), check=True)
+    r = run("docker volume inspect nc_app_skeleton_data".split())
+    assert r.returncode
+    # test "--force" option
+    deploy_register()
+    run("docker container stop nc_app_skeleton".split(), check=True)
+    r = run("php occ app_api:app:unregister skeleton".split())
+    assert r.returncode
+    run("php occ app_api:app:unregister skeleton --force".split(), check=True)


### PR DESCRIPTION
Fixes #121

- small actions clean up
- added basic but very useful tests for "occ app_api:app:unregister"

Changes in behaviour:

- container of app is always removed
- volume  with data is removed by default, but optionally can be kept
- app_api does not try to disable ExApp if it is already disabled
- "--silent" options now means "max silence as possible"
- added "--force" option to ignore errors if any. 