### PR TITLE
inverted ExApp `status.init_start_time` condition check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [1.4.3 - 2023-12-2x]
+
+### Fixed
+
+- invalid timeout condition check for `/init` endpoint. #155
+
 ## [1.4.2 - 2023-12-13]
 
 Maintenance update of npm packages to support NC28

--- a/lib/BackgroundJob/ExAppInitStatusCheckJob.php
+++ b/lib/BackgroundJob/ExAppInitStatusCheckJob.php
@@ -37,7 +37,7 @@ class ExAppInitStatusCheckJob extends TimedJob {
 				if (!isset($status['init_start_time'])) {
 					continue;
 				}
-				if (($status['init_start_time'] + $initTimeoutMinutes * 60) > time()) {
+				if (time() >= ($status['init_start_time'] + $initTimeoutMinutes * 60)) {
 					$this->service->setAppInitProgress(
 						$exApp->getAppid(), 0, sprintf('ExApp %s initialization timed out (%sm)', $exApp->getAppid(), $initTimeoutMinutes * 60)
 					);


### PR DESCRIPTION
Resolves #154 