### PR TITLE
added check of `host` value during daemon registration

### DIFF
--- a/lib/Service/DaemonConfigService.php
+++ b/lib/Service/DaemonConfigService.php
@@ -31,6 +31,14 @@ class DaemonConfigService {
 	}
 
 	public function registerDaemonConfig(array $params): ?DaemonConfig {
+		$bad_patterns = ['http', 'https', 'tcp', 'udp', 'ssh'];
+		$docker_host = (string)$params['host'];
+		foreach ($bad_patterns as $bad_pattern) {
+			if (str_starts_with($docker_host, $bad_pattern . '://')) {
+				$this->logger->error('Failed to register daemon configuration. `host` must not include a protocol.');
+				return null;
+			}
+		}
 		try {
 			$daemonConfig = $this->mapper->insert(new DaemonConfig([
 				'name' => $params['name'],

--- a/src/components/DaemonConfig/RegisterDaemonConfigModal.vue
+++ b/src/components/DaemonConfig/RegisterDaemonConfigModal.vue
@@ -52,8 +52,17 @@
 						<NcInputField
 							id="daemon-host"
 							:value.sync="host"
-							:placeholder="t('app_api', 'Daemon host (e.g. /var/run/docker.sock, https://proxy-domain.com:2375)')"
-							:aria-label="t('app_api', 'Daemon host (e.g. /var/run/docker.sock, https://proxy-domain.com:2375)')" />
+							:placeholder="t('app_api', 'Daemon host (e.g. /var/run/docker.sock, proxy-domain.com:2375)')"
+							:aria-label="t('app_api', 'Daemon host (e.g. /var/run/docker.sock, proxy-domain.com:2375)')"
+							:helper-text="daemonHostHelperText" />
+					</div>
+					<div v-if="acceptsDeployId !== 'manual-install'" class="external-label">
+						<label for="nextcloud-url">{{ t('app_api', 'Nextcloud url') }}</label>
+						<NcInputField
+							id="nextcloud-url"
+							:value.sync="nextcloud_url"
+							:placeholder="t('app_api', 'Nextcloud url')"
+							:aria-label="t('app_api', 'Nextcloud url')" />
 					</div>
 					<NcCheckboxRadioSwitch
 						v-if="acceptsDeployId !== 'manual-install'"
@@ -174,6 +183,16 @@ export default {
 			registeringDaemon: false,
 			registerInOneClickLoading: false,
 		}
+	},
+	computed: {
+		daemonHostHelperText() {
+			if (this.protocol === 'unix-socket') {
+				return t('app_api', 'Unix socket path (e.g. /var/run/docker.sock)')
+			} else if (['http', 'https'].includes(this.protocol)) {
+				return t('app_api', 'Host with port (e.g. proxy-domain.com:2375)')
+			}
+			return ''
+		},
 	},
 	watch: {
 		acceptsDeployId(newAcceptsDeployId) {


### PR DESCRIPTION
Ref: https://github.com/cloud-py-api/app_api/issues/153#issuecomment-1859634989

Small lazy check if `host` value starts from a protocol.
