### PR TITLE
updated docs for "api/v1/users" endpoint

### DIFF
--- a/docs/tech_details/api/utils.rst
+++ b/docs/tech_details/api/utils.rst
@@ -17,5 +17,14 @@ Returns a list of user IDs only.
 
 .. code-block:: json
 
-	["user1", "user2", "user3"]
-
+	{"ocs": {
+		"meta": {
+			"status": "ok",
+			"statuscode": 100,
+			"message": "OK",
+			"totalitems": "",
+			"itemsperpage": ""
+			},
+		"data": ["admin", "alice", "bob", "jane", "john"]
+		}
+	}


### PR DESCRIPTION
Old:
<img width="502" alt="image" src="https://github.com/cloud-py-api/app_api/assets/13381981/28e191d4-fcd7-4971-9547-3104548d9aea">


New:
<img width="487" alt="image" src="https://github.com/cloud-py-api/app_api/assets/13381981/4547c866-3169-4d2a-a0db-21d3207d6d9f">

Ref: https://github.com/cloud-py-api/app_api/issues/160