### PR TITLE
updated docs for api/v1/log "log_lvl" param

### DIFF
--- a/docs/tech_details/api/logging.rst
+++ b/docs/tech_details/api/logging.rst
@@ -20,9 +20,12 @@ Request data
 .. code-block:: json
 
 	{
-		"level": "loglevel",
+		"level": "log_lvl(integer)",
 		"message": "message",
 	}
+
+
+The possible value of ``log_lvl`` is described here: `Nextcloud Log level <https://docs.nextcloud.com/server/latest/admin_manual/configuration_server/logging_configuration.html#log-level>`_
 
 Response data
 *************


### PR DESCRIPTION
Old:

<img width="364" alt="image" src="https://github.com/cloud-py-api/app_api/assets/13381981/90d47503-9823-4690-86dd-e9c61d4c22a2">


New:

<img width="505" alt="image" src="https://github.com/cloud-py-api/app_api/assets/13381981/e84babcd-fe94-450a-a5bc-19ba85e0c4c8">

Ref: #160