### PR TITLE
requestToExApp: added CURLStringFile support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 - links to new apps that uses AppAPI. #158
+- added ability for `requestToExApp` and `aeRequestToExApp` methods, to send `multipart` requests. #168
 
 ### Fixed
 

--- a/lib/Service/AppAPIService.php
+++ b/lib/Service/AppAPIService.php
@@ -671,11 +671,12 @@ class AppAPIService {
 						];
 					}
 				}
+				if ($isMultipart) {
+					$options['multipart'] = $multipartData;
+				}
 			}
 
-			if ($isMultipart) {
-				$options['multipart'] = $multipartData;
-			} elseif (count($params) > 0) {
+			if ((!array_key_exists('multipart', $options)) && (count($params)) > 0) {
 				if ($method === 'GET') {
 					$url .= '?' . $this->getUriEncodedParams($params);
 				} else {

--- a/lib/Service/AppAPIService.php
+++ b/lib/Service/AppAPIService.php
@@ -652,7 +652,30 @@ class AppAPIService {
 				'allow_local_address' => true, // it's required as we are using ExApp appid as hostname (usually local)
 			];
 
-			if (count($params) > 0) {
+			$isMultipart = false;
+			$multipartData = [];
+			if ($method === 'POST' || $method === 'PUT') {
+				foreach ($params as $key => $value) {
+					if (is_a($value, 'CURLStringFile')) {
+						$isMultipart = true;
+						$multipartData[] = [
+							'name' => $key,
+							'contents' => $value->data,
+							'filename' => $value->postname,
+							'headers' => ['Content-Type' => $value->mime]
+						];
+					} else {
+						$multipartData[] = [
+							'name' => $key,
+							'contents' => $value
+						];
+					}
+				}
+			}
+
+			if ($isMultipart) {
+				$options['multipart'] = $multipartData;
+			} elseif (count($params) > 0) {
 				if ($method === 'GET') {
 					$url .= '?' . $this->getUriEncodedParams($params);
 				} else {


### PR DESCRIPTION
@kyteinsky, please look, is this what you need or not.
If yes, then I will continue and finish it today.

Usage([php watch ref](https://php.watch/versions/8.1/CURLStringFile)):

```php

$txt = 'test content';
$txt_curlfile = new \CURLStringFile($txt, 'test.txt', 'text/plain');
$this->service->aeRequestToExAppById('appid', '/upload_file', '', 'POST', ['file' => $txt_curlfile, 'notes' => 'lol']);
		
```

Usage from Python backend([fastapi ref](https://fastapi.tiangolo.com/tutorial/request-files/#request-files)):

```python3

@APP.post("/upload_file")
def upload_file(file: UploadFile, notes: Annotated[str | None, Form()] = None):
    print(notes)
    if notes is None:
        return responses.JSONResponse({"filename": file.filename, "size": file.size})
    return responses.JSONResponse({"filename": file.filename, "size": file.size, "notes": notes})
```   

"notes" is a `form` parameter, it is optional.

