### PR TITLE
do not bind all networks with `host` network on local daemon

### DIFF
--- a/.github/workflows/tests-deploy.yml
+++ b/.github/workflows/tests-deploy.yml
@@ -588,7 +588,7 @@ jobs:
             --admin-user admin --admin-pass admin
           ./occ config:system:set loglevel --value=0 --type=integer
           ./occ config:system:set debug --value=true --type=boolean
-          ./occ config:system:set overwrite.cli.url --value 127.0.0.1:8080 --type=string
+          ./occ config:system:set overwrite.cli.url --value http://127.0.0.1:8080 --type=string
           ./occ app:enable --force ${{ env.APP_NAME }}
 
       - name: Test deploy

--- a/.github/workflows/tests-deploy.yml
+++ b/.github/workflows/tests-deploy.yml
@@ -170,6 +170,7 @@ jobs:
           docker exec nextcloud sudo -u www-data php occ app_api:daemon:register \
             docker_local_sock Docker docker-install unix-socket /var/run/docker.sock http://nextcloud/index.php \
             --net=master_bridge
+          docker exec nextcloud sudo -u www-data php occ app_api:daemon:list
           docker exec nextcloud sudo -u www-data php occ app_api:app:deploy skeleton docker_local_sock \
             --info-xml https://raw.githubusercontent.com/cloud-py-api/nc_py_api/main/examples/as_app/skeleton/appinfo/info.xml
           docker exec nextcloud sudo -u www-data php occ app_api:app:register skeleton docker_local_sock \
@@ -251,6 +252,7 @@ jobs:
           docker exec nextcloud sudo -u www-data php occ app_api:daemon:register \
             docker_by_port Docker docker-install https host.docker.internal:8443 http://nextcloud/index.php \
             --net=master_bridge --ssl_cert /client/cert.pem --ssl_key /client/key.pem
+          docker exec nextcloud sudo -u www-data php occ app_api:daemon:list
           docker exec nextcloud sudo -u www-data php occ app_api:app:deploy skeleton docker_by_port \
             --info-xml https://raw.githubusercontent.com/cloud-py-api/nc_py_api/main/examples/as_app/skeleton/appinfo/info.xml
           docker exec nextcloud sudo -u www-data php occ app_api:app:register skeleton docker_by_port \
@@ -331,6 +333,7 @@ jobs:
           docker exec nextcloud sudo -u www-data php occ app_api:daemon:register \
             docker_by_port Docker docker-install https host.docker.internal:8443 http://localhost:8080/index.php \
             --net=host --hostname=host.docker.internal --ssl_cert /client/cert.pem --ssl_key /client/key.pem
+          docker exec nextcloud sudo -u www-data php occ app_api:daemon:list
           docker exec nextcloud sudo -u www-data php occ app_api:app:deploy skeleton docker_by_port \
             --info-xml https://raw.githubusercontent.com/cloud-py-api/nc_py_api/main/examples/as_app/skeleton/appinfo/info.xml
           docker exec nextcloud sudo -u www-data php occ app_api:app:register skeleton docker_by_port \
@@ -468,6 +471,7 @@ jobs:
         run: |
           PHP_CLI_SERVER_WORKERS=2 php -S 127.0.0.1:8080 &
           ./occ app_api:daemon:register docker_local_sock Docker docker-install unix-socket /var/run/docker.sock http://127.0.0.1:8080/index.php
+          ./occ app_api:daemon:list
           ./occ app_api:app:deploy skeleton docker_local_sock \
             --info-xml https://raw.githubusercontent.com/cloud-py-api/nc_py_api/main/examples/as_app/skeleton/appinfo/info.xml
           ./occ app_api:app:register skeleton docker_local_sock \
@@ -589,6 +593,7 @@ jobs:
       - name: Test deploy
         run: |
           PHP_CLI_SERVER_WORKERS=2 php -S 127.0.0.1:8080 &
+          ./occ app_api:daemon:list
           ./occ app_api:app:deploy skeleton \
             --info-xml https://raw.githubusercontent.com/cloud-py-api/nc_py_api/main/examples/as_app/skeleton/appinfo/info.xml
           ./occ app_api:app:register skeleton \

--- a/.github/workflows/tests-deploy.yml
+++ b/.github/workflows/tests-deploy.yml
@@ -383,15 +383,7 @@ jobs:
 
   nc-host-app-docker-redis:
     runs-on: ubuntu-22.04
-    name: NC In Host(Redis) • ${{ matrix.server-version }} • 🐘${{ matrix.php-version }}
-    strategy:
-      fail-fast: false
-      matrix:
-        php-version: [ '8.1' ]
-        server-version: [ 'stable27' ]
-        include:
-          - server-version: "master"
-            php-version: "8.2"
+    name: NC In Host(Redis) • stable27 • 🐘8.1
 
     services:
       postgres:
@@ -412,7 +404,7 @@ jobs:
           --health-retries 5
           --name redis
         ports:
-         - 6379:6379
+          - 6379:6379
 
     steps:
       - name: Set app env
@@ -423,17 +415,17 @@ jobs:
         with:
           submodules: true
           repository: nextcloud/server
-          ref: ${{ matrix.server-version }}
+          ref: stable27
 
       - name: Checkout AppAPI
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
         with:
           path: apps/${{ env.APP_NAME }}
 
-      - name: Set up php ${{ matrix.php-version }}
+      - name: Set up php 8.1
         uses: shivammathur/setup-php@4bd44f22a98a19e0950cbad5f31095157cc9621b # v2
         with:
-          php-version: ${{ matrix.php-version }}
+          php-version: 8.1
           extensions: bz2, ctype, curl, dom, fileinfo, gd, iconv, intl, json, libxml, mbstring, openssl, pcntl, posix, session, simplexml, xmlreader, xmlwriter, zip, zlib, pgsql, pdo_pgsql, redis
           coverage: none
           ini-file: development
@@ -510,7 +502,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: nc_host_app_docker_redis_${{ matrix.server-version }}_${{ matrix.php-version }}_container.json
+          name: nc_host_app_docker_redis_stable27_8.1_container.json
           path: container.json
           if-no-files-found: warn
 
@@ -518,7 +510,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: nc_host_app_docker_redis_${{ matrix.server-version }}_${{ matrix.php-version }}_container.log
+          name: nc_host_app_docker_redis_stable27_8.1_container.log
           path: container.log
           if-no-files-found: warn
 
@@ -526,7 +518,124 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: nc_host_app_docker_redis_${{ matrix.server-version }}_${{ matrix.php-version }}_nextcloud.log
+          name: nc_host_app_docker_redis_stable27_8.1_nextcloud.log
+          path: data/nextcloud.log
+          if-no-files-found: warn
+
+  nc-host-network-host:
+    runs-on: ubuntu-22.04
+    name: NC In Host(network=host)  • master • 🐘8.2
+
+    services:
+      postgres:
+        image: ghcr.io/nextcloud/continuous-integration-postgres-14:latest
+        ports:
+          - 4444:5432/tcp
+        env:
+          POSTGRES_USER: root
+          POSTGRES_PASSWORD: rootpassword
+          POSTGRES_DB: nextcloud
+        options: --health-cmd pg_isready --health-interval 5s --health-timeout 2s --health-retries 5
+
+    steps:
+      - name: Set app env
+        run: echo "APP_NAME=${GITHUB_REPOSITORY##*/}" >> $GITHUB_ENV
+
+      - name: Checkout server
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+        with:
+          submodules: true
+          repository: nextcloud/server
+          ref: master
+
+      - name: Checkout AppAPI
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+        with:
+          path: apps/${{ env.APP_NAME }}
+
+      - name: Set up php 8.2
+        uses: shivammathur/setup-php@4bd44f22a98a19e0950cbad5f31095157cc9621b # v2
+        with:
+          php-version: 8.2
+          extensions: bz2, ctype, curl, dom, fileinfo, gd, iconv, intl, json, libxml, mbstring, openssl, pcntl, posix, session, simplexml, xmlreader, xmlwriter, zip, zlib, pgsql, pdo_pgsql, redis
+          coverage: none
+          ini-file: development
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check composer file existence
+        id: check_composer
+        uses: andstor/file-existence-action@20b4d2e596410855db8f9ca21e96fbe18e12930b # v2
+        with:
+          files: apps/${{ env.APP_NAME }}/composer.json
+
+      - name: Set up dependencies
+        if: steps.check_composer.outputs.files_exists == 'true'
+        working-directory: apps/${{ env.APP_NAME }}
+        run: composer i
+
+      - name: Set up Nextcloud
+        env:
+          DB_PORT: 4444
+        run: |
+          mkdir data
+          ./occ maintenance:install --verbose --database=pgsql --database-name=nextcloud --database-host=127.0.0.1 \
+            --database-port=$DB_PORT --database-user=root --database-pass=rootpassword \
+            --admin-user admin --admin-pass admin
+          ./occ config:system:set loglevel --value=0 --type=integer
+          ./occ config:system:set debug --value=true --type=boolean
+          ./occ app:enable --force ${{ env.APP_NAME }}
+
+      - name: Test deploy
+        run: |
+          PHP_CLI_SERVER_WORKERS=2 php -S 127.0.0.1:8080 &
+          ./occ app_api:app:deploy skeleton \
+            --info-xml https://raw.githubusercontent.com/cloud-py-api/nc_py_api/main/examples/as_app/skeleton/appinfo/info.xml
+          ./occ app_api:app:register skeleton \
+            --info-xml https://raw.githubusercontent.com/cloud-py-api/nc_py_api/main/examples/as_app/skeleton/appinfo/info.xml
+          ./occ app_api:app:enable skeleton
+          ./occ app_api:app:disable skeleton
+
+      - name: Check logs
+        run: |
+          grep -q 'Hello from skeleton :)' data/nextcloud.log || error
+          grep -q 'Bye bye from skeleton :(' data/nextcloud.log || error
+
+      - name: Save container ingo & logs
+        if: always()
+        run: |
+          docker inspect nc_app_skeleton | json_pp > container.json
+          docker logs nc_app_skeleton > container.log 2>&1
+
+      - name: Unregister Skeleton & Daemon
+        run: |
+          ./occ app_api:app:unregister skeleton
+          ./occ app_api:daemon:unregister docker_socket_local
+
+      - name: Test OCC commands(docker)
+        run: python3 apps/${{ env.APP_NAME }}/tests/test_occ_commands_docker.py
+
+      - name: Upload Container info
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: nc_host_network_host_master_8.2_container.json
+          path: container.json
+          if-no-files-found: warn
+
+      - name: Upload Container logs
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: nc_host_network_host_master_8.2_container.log
+          path: container.log
+          if-no-files-found: warn
+
+      - name: Upload NC logs
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: nc_host_network_host_master_8.2_nextcloud.log
           path: data/nextcloud.log
           if-no-files-found: warn
 
@@ -535,7 +644,7 @@ jobs:
       contents: none
     runs-on: ubuntu-22.04
     needs: [nc-host-app-docker, nc-docker-app-docker, nc-docker-app-docker-by-port,
-            nc-docker-app-host-by-hostname, nc-host-app-docker-redis]
+            nc-docker-app-host-by-hostname, nc-host-app-docker-redis, nc-host-network-host]
     name: Tests-Deploy-OK
     steps:
       - run: echo "Tests-Deploy passed successfully"

--- a/.github/workflows/tests-deploy.yml
+++ b/.github/workflows/tests-deploy.yml
@@ -588,6 +588,7 @@ jobs:
             --admin-user admin --admin-pass admin
           ./occ config:system:set loglevel --value=0 --type=integer
           ./occ config:system:set debug --value=true --type=boolean
+          ./occ config:system:set overwrite.cli.url --value 127.0.0.1:8080 --type=string
           ./occ app:enable --force ${{ env.APP_NAME }}
 
       - name: Test deploy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-## [1.4.4 - 2023-12-xx]
+## [1.4.4 - 2023-12-2x]
 
 ### Added
 
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Processing of invalid default Nextcloud URL/incorrect url with slash at the end. #169
 - `occ app_api:app:register` error message in case of missing deploy of ExApp. #172
+- Default Docker Daemon(`not for AIO`) configuration should be better now. #173
 
 ## [1.4.3 - 2023-12-18]
 

--- a/lib/DeployActions/DockerActions.php
+++ b/lib/DeployActions/DockerActions.php
@@ -588,6 +588,7 @@ class DockerActions implements IDeployActions {
 	}
 
 	public function registerDefaultDaemonConfig(): ?DaemonConfig {
+		# default config means that NC is installed into host, and all ExApps are installed in the hosts network.
 		$defaultDaemonConfig = $this->config->getAppValue(Application::APP_ID, 'default_daemon_config', '');
 		if ($defaultDaemonConfig !== '') {
 			$daemonConfig = $this->daemonConfigService->getDaemonConfigByName($defaultDaemonConfig);
@@ -598,7 +599,7 @@ class DockerActions implements IDeployActions {
 
 		$deployConfig = [
 			'net' => 'host', // TODO: Add ExApp skeleton heartbeat check to verify default configuration works or manual configuration required
-			'host' => null,
+			'host' => 'localhost',
 			'nextcloud_url' => str_replace('https', 'http', $this->urlGenerator->getAbsoluteURL('/index.php')),
 			'ssl_key' => null,
 			'ssl_key_password' => null,

--- a/lib/Service/AppAPIService.php
+++ b/lib/Service/AppAPIService.php
@@ -737,7 +737,7 @@ class AppAPIService {
 			if (($deployConfig['net'] === 'host') &&
 				(isset($deployConfig['host']) && $this->isAppHostNameLocal($deployConfig['host']))
 			) {
-				return '127.0.0.1';  # ExApp using host network, it is visible for Nextcloud on loop-back adapter
+				return '127.0.0.1';  # ExApp using this host network, it is visible for Nextcloud on loop-back adapter
 			}
 			return '0.0.0.0';
 		}


### PR DESCRIPTION
The default daemon configuration (not including AIO, since we have a separate default configuration for AIO) sets:

* That all ExApp uses the host network interface
* That AppAPI refers to them by container name

This PR corrects the second point, so that AppAPI would contact ExApp via `localhost` in this case, because when `host` as network is used, the DNS for containers names does not work, and the container name cannot be accessed in any way.

**Also this PR adds a test for the default configuration.**

Changes in `buildExAppHost`:

```php

public function buildExAppHost(array $deployConfig): string {
	if ((isset($deployConfig['net']) && $deployConfig['net'] !== 'host') || isset($deployConfig['host'])) {
		return '0.0.0.0';
	}
	return '127.0.0.1';
}
```

**-->**	

```php

public function isAppHostNameLocal(string $hostname): bool {
	return $hostname === '127.0.0.1' || $hostname === 'localhost' || $hostname === '::1';
}

public function buildExAppHost(array $deployConfig): string {
	if (isset($deployConfig['net'])) {
		if (($deployConfig['net'] === 'host') &&
			(isset($deployConfig['host']) && $this->isAppHostNameLocal($deployConfig['host']))
		) {
			return '127.0.0.1';  # ExApp using this host network, it is visible for Nextcloud on loop-back adapter
		}
		return '0.0.0.0';
	}
	return '127.0.0.1';  # fallback to loop-back adapter
}
```

This is more security change, to not bind `0.0.0.0` in ExApp when host network is used, as ExApp should be reachable for Nextcloud using loop-back.
From my point it is a not big problem to bind `0.0.0.0` as anyway instance in production should be shielded by firewall, but anyway it is more elegant.

P.S: I am not sure should we fallback to `0.0.0.0` or to `127.0.0.1`, so leave into as it was before without changing.