### PR TITLE
CI: added installation of the Notes app

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -74,6 +74,14 @@ jobs:
         with:
           path: apps/${{ env.APP_NAME }}
 
+      - name: Checkout Notes
+        uses: actions/checkout@v4
+        if: ${{ !startsWith(matrix.nextcloud, 'master') }}
+        with:
+          repository: nextcloud/notes
+          ref: "main"
+          path: apps/notes
+
       - name: Set up php ${{ matrix.php-version }}
         uses: shivammathur/setup-php@4bd44f22a98a19e0950cbad5f31095157cc9621b # v2
         with:
@@ -105,6 +113,10 @@ jobs:
             --admin-user admin --admin-pass admin
           ./occ app:enable notifications
           ./occ app:enable --force ${{ env.APP_NAME }}
+
+      - name: Enable Notes
+        if: ${{ !startsWith(matrix.nextcloud, 'master') }}
+        run: ./occ app:enable notes
 
       - name: Run Nextcloud
         run: PHP_CLI_SERVER_WORKERS=2 php -S 127.0.0.1:8080 &

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -76,7 +76,7 @@ jobs:
 
       - name: Checkout Notes
         uses: actions/checkout@v4
-        if: ${{ !startsWith(matrix.nextcloud, 'master') }}
+        if: ${{ !startsWith(matrix.server-version, 'master') }}
         with:
           repository: nextcloud/notes
           ref: "main"
@@ -115,7 +115,7 @@ jobs:
           ./occ app:enable --force ${{ env.APP_NAME }}
 
       - name: Enable Notes
-        if: ${{ !startsWith(matrix.nextcloud, 'master') }}
+        if: ${{ !startsWith(matrix.server-version, 'master') }}
         run: ./occ app:enable notes
 
       - name: Run Nextcloud


### PR DESCRIPTION
During this PR(https://github.com/cloud-py-api/app_api/pull/184) we had found that in some cases we can broke the AppAPI Auth.

This PR adds check for this, as CORS bypassing is used for the Notes app to work and it is achieved by setting 'app_api' session key.