### PR TITLE
Small bug in getRegisteredFileActions and getExAppMenuEntries

### DIFF
--- a/lib/Service/UI/FilesActionsMenuService.php
+++ b/lib/Service/UI/FilesActionsMenuService.php
@@ -91,23 +91,21 @@ class FilesActionsMenuService {
 	/**
 	 * Get list of registered file actions (only for enabled ExApps)
 	 *
-	 * @return FilesActionsMenu[]|null
+	 * @return FilesActionsMenu[]
 	 */
-	public function getRegisteredFileActions(): ?array {
+	public function getRegisteredFileActions(): array {
 		try {
 			$cacheKey = '/ex_ui_files_actions';
-			$cached = $this->cache->get($cacheKey);
-			if ($cached !== null) {
-				return array_map(function ($cacheEntry) {
-					return $cacheEntry instanceof FilesActionsMenu ? $cacheEntry : new FilesActionsMenu($cacheEntry);
-				}, $cached);
+			$records = $this->cache->get($cacheKey);
+			if ($records === null) {
+				$records = $this->mapper->findAllEnabled();
+				$this->cache->set($cacheKey, $records);
 			}
-
-			$fileActions = $this->mapper->findAllEnabled();
-			$this->cache->set($cacheKey, $fileActions);
-			return $fileActions;
+			return array_map(function ($record) {
+				return new FilesActionsMenu($record);
+			}, $records);
 		} catch (Exception) {
-			return null;
+			return [];
 		}
 	}
 

--- a/lib/Service/UI/TopMenuService.php
+++ b/lib/Service/UI/TopMenuService.php
@@ -142,18 +142,22 @@ class TopMenuService {
 		return $menuEntry;
 	}
 
+	/**
+	 * Get list of registered TopMenu entries (only for enabled ExApps)
+	 *
+	 * @return TopMenu[]
+	 */
 	public function getExAppMenuEntries(): array {
 		try {
 			$cacheKey = '/ex_top_menus';
-			$cached = $this->cache->get($cacheKey);
-			if ($cached !== null) {
-				return array_map(function ($cacheEntry) {
-					return $cacheEntry instanceof TopMenu ? $cacheEntry : new TopMenu($cacheEntry);
-				}, $cached);
+			$records = $this->cache->get($cacheKey);
+			if ($records === null) {
+				$records = $this->mapper->findAllEnabled();
+				$this->cache->set($cacheKey, $records);
 			}
-			$menuEntries = $this->mapper->findAllEnabled();
-			$this->cache->set($cacheKey, $menuEntries);
-			return $menuEntries;
+			return array_map(function ($record) {
+				return new TopMenu($record);
+			}, $records);
 		} catch (Exception) {
 			return [];
 		}


### PR DESCRIPTION
**Fixed getRegisteredFileActions/getExAppMenuEntries returning wrong result on first call**


_Issue was found during implementing SpeechToText Provider API, as this internal APIs has the same struct._