### PR TITLE
`ALL` ApiScope

### DIFF
--- a/.github/workflows/tests-special.yml
+++ b/.github/workflows/tests-special.yml
@@ -226,7 +226,7 @@ jobs:
           timeout 3m tail --pid=$(cat /tmp/_install.pid) -f /dev/null
 
       - name: Check logs
-        run: grep -q 'Hello from $APP_ID :)' data/nextcloud.log || error
+        run: grep -q 'Hello from ' data/nextcloud.log || error
 
       - name: Test Scope ALL
         run: python3 apps/${{ env.APP_NAME }}/tests/auth_scopes_system.py 0

--- a/.github/workflows/tests-special.yml
+++ b/.github/workflows/tests-special.yml
@@ -164,13 +164,6 @@ jobs:
           repository: nextcloud/server
           ref: 'stable27'
 
-      - name: Checkout Notifications
-        uses: actions/checkout@v3
-        with:
-          repository: nextcloud/notifications
-          ref: ${{ matrix.server-version }}
-          path: apps/notifications
-
       - name: Checkout AppAPI
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
         with:
@@ -205,7 +198,6 @@ jobs:
           ./occ maintenance:install --verbose --database=pgsql --database-name=nextcloud --database-host=127.0.0.1 \
             --database-port=$DB_PORT --database-user=root --database-pass=rootpassword \
             --admin-user admin --admin-pass admin
-          ./occ app:enable notifications
           ./occ app:enable --force ${{ env.APP_NAME }}
 
       - name: Run Nextcloud
@@ -233,6 +225,11 @@ jobs:
           kill -15 $(cat /tmp/_install.pid)
           timeout 3m tail --pid=$(cat /tmp/_install.pid) -f /dev/null
 
+      - name: Check logs
+        run: |
+          grep -q 'Hello from {{ env.APP_ID }} :)' data/nextcloud.log || error
+          grep -q 'Bye bye from {{ env.APP_ID }} :(' data/nextcloud.log || error
+
       - name: Upload NC logs
         if: always()
         uses: actions/upload-artifact@v3
@@ -240,6 +237,113 @@ jobs:
           name: install_no_init.log
           path: data/nextcloud.log
           if-no-files-found: warn
+
+#  auth-all-scope:
+#    runs-on: ubuntu-22.04
+#    name: Auth ALL, SYSTEM
+#
+#    services:
+#      postgres:
+#        image: ghcr.io/nextcloud/continuous-integration-postgres-14:latest
+#        ports:
+#          - 4444:5432/tcp
+#        env:
+#          POSTGRES_USER: root
+#          POSTGRES_PASSWORD: rootpassword
+#          POSTGRES_DB: nextcloud
+#        options: --health-cmd pg_isready --health-interval 5s --health-timeout 2s --health-retries 5
+#
+#    steps:
+#      - uses: actions/setup-python@v4
+#        with:
+#          python-version: '3.11'
+#
+#      - name: Set app env
+#        run: echo "APP_NAME=${GITHUB_REPOSITORY##*/}" >> $GITHUB_ENV
+#
+#      - name: Checkout server
+#        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+#        with:
+#          submodules: true
+#          repository: nextcloud/server
+#          ref: 'stable28'
+#
+#      - name: Checkout Notifications
+#        uses: actions/checkout@v3
+#        with:
+#          repository: nextcloud/notifications
+#          ref: ${{ matrix.server-version }}
+#          path: apps/notifications
+#
+#      - name: Checkout AppAPI
+#        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+#        with:
+#          path: apps/${{ env.APP_NAME }}
+#
+#      - name: Set up php
+#        uses: shivammathur/setup-php@4bd44f22a98a19e0950cbad5f31095157cc9621b # v2
+#        with:
+#          php-version: '8.1'
+#          extensions: bz2, ctype, curl, dom, fileinfo, gd, iconv, intl, json, libxml, mbstring, openssl, pcntl, posix, session, simplexml, xmlreader, xmlwriter, zip, zlib, pgsql, pdo_pgsql
+#          coverage: none
+#          ini-file: development
+#        env:
+#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#
+#      - name: Check composer file existence
+#        id: check_composer
+#        uses: andstor/file-existence-action@20b4d2e596410855db8f9ca21e96fbe18e12930b # v2
+#        with:
+#          files: apps/${{ env.APP_NAME }}/composer.json
+#
+#      - name: Set up dependencies
+#        if: steps.check_composer.outputs.files_exists == 'true'
+#        working-directory: apps/${{ env.APP_NAME }}
+#        run: composer i
+#
+#      - name: Set up Nextcloud
+#        env:
+#          DB_PORT: 4444
+#        run: |
+#          mkdir data
+#          ./occ maintenance:install --verbose --database=pgsql --database-name=nextcloud --database-host=127.0.0.1 \
+#            --database-port=$DB_PORT --database-user=root --database-pass=rootpassword \
+#            --admin-user admin --admin-pass admin
+#          ./occ app:enable notifications
+#          ./occ app:enable --force ${{ env.APP_NAME }}
+#
+#      - name: Run Nextcloud
+#        run: PHP_CLI_SERVER_WORKERS=2 php -S 127.0.0.1:8080 &
+#
+#      - name: Checkout NcPyApi
+#        uses: actions/checkout@v3
+#        with:
+#          path: nc_py_api
+#          repository: cloud-py-api/nc_py_api
+#
+#      - name: Install NcPyApi
+#        working-directory: nc_py_api
+#        run: python3 -m pip -v install ".[dev]"
+#
+#      - name: Register NcPyApi
+#        run: |
+#          python3 apps/${{ env.APP_NAME }}/tests/install_no_init.py &
+#          echo $! > /tmp/_install.pid
+#          sleep 5s
+#          php occ app_api:daemon:register manual_install "Manual Install" manual-install 0 0 0
+#          php occ app_api:app:register nc_py_api manual_install --json-info \
+#            "{\"appid\":\"$APP_ID\",\"name\":\"$APP_ID\",\"daemon_config_name\":\"manual_install\",\"version\":\"$APP_VERSION\",\"secret\":\"$APP_SECRET\",\"host\":\"localhost\",\"port\":$APP_PORT,\"scopes\":{\"required\":[\"SYSTEM\", \"FILES\", \"FILES_SHARING\"],\"optional\":[\"USER_INFO\", \"USER_STATUS\", \"NOTIFICATIONS\", \"WEATHER_STATUS\", \"TALK\"]},\"protocol\":\"http\",\"system_app\":1}" \
+#            --force-scopes --wait-finish
+#          kill -15 $(cat /tmp/_install.pid)
+#          timeout 3m tail --pid=$(cat /tmp/_install.pid) -f /dev/null
+#
+#      - name: Upload NC logs
+#        if: always()
+#        uses: actions/upload-artifact@v3
+#        with:
+#          name: install_no_init.log
+#          path: data/nextcloud.log
+#          if-no-files-found: warn
 
   tests-special-success:
     permissions:

--- a/.github/workflows/tests-special.yml
+++ b/.github/workflows/tests-special.yml
@@ -228,7 +228,7 @@ jobs:
       - name: Check logs
         run: grep -q 'Hello from ' data/nextcloud.log || error
 
-      - name: Test Scope ALL
+      - name: Test ALL Scope, System App
         run: python3 apps/${{ env.APP_NAME }}/tests/auth_scopes_system.py 0
 
       - name: Re-Register App
@@ -243,7 +243,22 @@ jobs:
           kill -15 $(cat /tmp/_install.pid)
           timeout 3m tail --pid=$(cat /tmp/_install.pid) -f /dev/null
 
-      - name: Test No Scope ALL
+      - name: Test NO ALL Scope, System App
+        run: python3 apps/${{ env.APP_NAME }}/tests/auth_scopes_system.py 1
+
+      - name: Re-Register App
+        run: |
+          php occ app_api:app:unregister $APP_ID --silent || true
+          python3 apps/${{ env.APP_NAME }}/tests/install_no_init.py &
+          echo $! > /tmp/_install.pid
+          sleep 5s
+          php occ app_api:app:register $APP_ID manual_install --json-info \
+            "{\"appid\":\"$APP_ID\",\"name\":\"$APP_ID\",\"daemon_config_name\":\"manual_install\",\"version\":\"$APP_VERSION\",\"secret\":\"$APP_SECRET\",\"host\":\"localhost\",\"port\":$APP_PORT,\"scopes\":{\"required\":[\"ALL\"],\"optional\":[]},\"protocol\":\"http\",\"system_app\":0}" \
+            --force-scopes --wait-finish
+          kill -15 $(cat /tmp/_install.pid)
+          timeout 3m tail --pid=$(cat /tmp/_install.pid) -f /dev/null
+
+      - name: Test NO ALL Scope, NO System App
         run: python3 apps/${{ env.APP_NAME }}/tests/auth_scopes_system.py 1
 
       - name: Upload NC logs

--- a/.github/workflows/tests-special.yml
+++ b/.github/workflows/tests-special.yml
@@ -226,9 +226,7 @@ jobs:
           timeout 3m tail --pid=$(cat /tmp/_install.pid) -f /dev/null
 
       - name: Check logs
-        run: |
-          grep -q 'Hello from {{ env.APP_ID }} :)' data/nextcloud.log || error
-          grep -q 'Bye bye from {{ env.APP_ID }} :(' data/nextcloud.log || error
+        run: grep -q 'Hello from' data/nextcloud.log || error
 
       - name: Upload NC logs
         if: always()

--- a/.github/workflows/tests-special.yml
+++ b/.github/workflows/tests-special.yml
@@ -116,8 +116,8 @@ jobs:
           cd ..
           sleep 5s
           php occ app_api:daemon:register manual_install "Manual Install" manual-install 0 0 0
-          php occ app_api:app:register nc_py_api manual_install --json-info \
-            "{\"appid\":\"$APP_ID\",\"name\":\"$APP_ID\",\"daemon_config_name\":\"manual_install\",\"version\":\"$APP_VERSION\",\"secret\":\"$APP_SECRET\",\"host\":\"localhost\",\"port\":$APP_PORT,\"scopes\":{\"required\":[\"SYSTEM\", \"FILES\", \"FILES_SHARING\"],\"optional\":[\"USER_INFO\", \"USER_STATUS\", \"NOTIFICATIONS\", \"WEATHER_STATUS\", \"TALK\"]},\"protocol\":\"http\",\"system_app\":1}" \
+          php occ app_api:app:register $APP_ID manual_install --json-info \
+            "{\"appid\":\"$APP_ID\",\"name\":\"$APP_ID\",\"daemon_config_name\":\"manual_install\",\"version\":\"$APP_VERSION\",\"secret\":\"$APP_SECRET\",\"host\":\"localhost\",\"port\":$APP_PORT,\"scopes\":{\"required\":[\"SYSTEM\", \"NOTIFICATIONS\"],\"optional\":[\"USER_INFO\"]},\"protocol\":\"http\",\"system_app\":1}" \
             --force-scopes --wait-finish
           kill -15 $(cat /tmp/_install.pid)
           timeout 3m tail --pid=$(cat /tmp/_install.pid) -f /dev/null
@@ -134,9 +134,9 @@ jobs:
           path: data/nextcloud.log
           if-no-files-found: warn
 
-  no-init-endpoint:
+  auth-tests-no-init:
     runs-on: ubuntu-22.04
-    name: Without Init Endpoint
+    name: Auth tests (no Init endpoint)
 
     services:
       postgres:
@@ -213,20 +213,38 @@ jobs:
         working-directory: nc_py_api
         run: python3 -m pip -v install ".[dev]"
 
-      - name: Register NcPyApi
+      - name: Register App
         run: |
           python3 apps/${{ env.APP_NAME }}/tests/install_no_init.py &
           echo $! > /tmp/_install.pid
           sleep 5s
           php occ app_api:daemon:register manual_install "Manual Install" manual-install 0 0 0
-          php occ app_api:app:register nc_py_api manual_install --json-info \
-            "{\"appid\":\"$APP_ID\",\"name\":\"$APP_ID\",\"daemon_config_name\":\"manual_install\",\"version\":\"$APP_VERSION\",\"secret\":\"$APP_SECRET\",\"host\":\"localhost\",\"port\":$APP_PORT,\"scopes\":{\"required\":[\"SYSTEM\", \"FILES\", \"FILES_SHARING\"],\"optional\":[\"USER_INFO\", \"USER_STATUS\", \"NOTIFICATIONS\", \"WEATHER_STATUS\", \"TALK\"]},\"protocol\":\"http\",\"system_app\":1}" \
+          php occ app_api:app:register $APP_ID manual_install --json-info \
+            "{\"appid\":\"$APP_ID\",\"name\":\"$APP_ID\",\"daemon_config_name\":\"manual_install\",\"version\":\"$APP_VERSION\",\"secret\":\"$APP_SECRET\",\"host\":\"localhost\",\"port\":$APP_PORT,\"scopes\":{\"required\":[\"ALL\"],\"optional\":[]},\"protocol\":\"http\",\"system_app\":0}" \
             --force-scopes --wait-finish
           kill -15 $(cat /tmp/_install.pid)
           timeout 3m tail --pid=$(cat /tmp/_install.pid) -f /dev/null
 
       - name: Check logs
-        run: grep -q 'Hello from' data/nextcloud.log || error
+        run: grep -q 'Hello from $APP_ID :)' data/nextcloud.log || error
+
+      - name: Test Scope ALL
+        run: python3 apps/${{ env.APP_NAME }}/tests/auth_scopes_system.py 0
+
+      - name: Re-Register App
+        run: |
+          php occ app_api:app:unregister $APP_ID --silent || true
+          python3 apps/${{ env.APP_NAME }}/tests/install_no_init.py &
+          echo $! > /tmp/_install.pid
+          sleep 5s
+          php occ app_api:app:register $APP_ID manual_install --json-info \
+            "{\"appid\":\"$APP_ID\",\"name\":\"$APP_ID\",\"daemon_config_name\":\"manual_install\",\"version\":\"$APP_VERSION\",\"secret\":\"$APP_SECRET\",\"host\":\"localhost\",\"port\":$APP_PORT,\"scopes\":{\"required\":[\"SYSTEM\"],\"optional\":[]},\"protocol\":\"http\",\"system_app\":0}" \
+            --force-scopes --wait-finish
+          kill -15 $(cat /tmp/_install.pid)
+          timeout 3m tail --pid=$(cat /tmp/_install.pid) -f /dev/null
+
+      - name: Test No Scope ALL
+        run: python3 apps/${{ env.APP_NAME }}/tests/auth_scopes_system.py 1
 
       - name: Upload NC logs
         if: always()
@@ -236,118 +254,11 @@ jobs:
           path: data/nextcloud.log
           if-no-files-found: warn
 
-#  auth-all-scope:
-#    runs-on: ubuntu-22.04
-#    name: Auth ALL, SYSTEM
-#
-#    services:
-#      postgres:
-#        image: ghcr.io/nextcloud/continuous-integration-postgres-14:latest
-#        ports:
-#          - 4444:5432/tcp
-#        env:
-#          POSTGRES_USER: root
-#          POSTGRES_PASSWORD: rootpassword
-#          POSTGRES_DB: nextcloud
-#        options: --health-cmd pg_isready --health-interval 5s --health-timeout 2s --health-retries 5
-#
-#    steps:
-#      - uses: actions/setup-python@v4
-#        with:
-#          python-version: '3.11'
-#
-#      - name: Set app env
-#        run: echo "APP_NAME=${GITHUB_REPOSITORY##*/}" >> $GITHUB_ENV
-#
-#      - name: Checkout server
-#        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
-#        with:
-#          submodules: true
-#          repository: nextcloud/server
-#          ref: 'stable28'
-#
-#      - name: Checkout Notifications
-#        uses: actions/checkout@v3
-#        with:
-#          repository: nextcloud/notifications
-#          ref: ${{ matrix.server-version }}
-#          path: apps/notifications
-#
-#      - name: Checkout AppAPI
-#        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
-#        with:
-#          path: apps/${{ env.APP_NAME }}
-#
-#      - name: Set up php
-#        uses: shivammathur/setup-php@4bd44f22a98a19e0950cbad5f31095157cc9621b # v2
-#        with:
-#          php-version: '8.1'
-#          extensions: bz2, ctype, curl, dom, fileinfo, gd, iconv, intl, json, libxml, mbstring, openssl, pcntl, posix, session, simplexml, xmlreader, xmlwriter, zip, zlib, pgsql, pdo_pgsql
-#          coverage: none
-#          ini-file: development
-#        env:
-#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-#
-#      - name: Check composer file existence
-#        id: check_composer
-#        uses: andstor/file-existence-action@20b4d2e596410855db8f9ca21e96fbe18e12930b # v2
-#        with:
-#          files: apps/${{ env.APP_NAME }}/composer.json
-#
-#      - name: Set up dependencies
-#        if: steps.check_composer.outputs.files_exists == 'true'
-#        working-directory: apps/${{ env.APP_NAME }}
-#        run: composer i
-#
-#      - name: Set up Nextcloud
-#        env:
-#          DB_PORT: 4444
-#        run: |
-#          mkdir data
-#          ./occ maintenance:install --verbose --database=pgsql --database-name=nextcloud --database-host=127.0.0.1 \
-#            --database-port=$DB_PORT --database-user=root --database-pass=rootpassword \
-#            --admin-user admin --admin-pass admin
-#          ./occ app:enable notifications
-#          ./occ app:enable --force ${{ env.APP_NAME }}
-#
-#      - name: Run Nextcloud
-#        run: PHP_CLI_SERVER_WORKERS=2 php -S 127.0.0.1:8080 &
-#
-#      - name: Checkout NcPyApi
-#        uses: actions/checkout@v3
-#        with:
-#          path: nc_py_api
-#          repository: cloud-py-api/nc_py_api
-#
-#      - name: Install NcPyApi
-#        working-directory: nc_py_api
-#        run: python3 -m pip -v install ".[dev]"
-#
-#      - name: Register NcPyApi
-#        run: |
-#          python3 apps/${{ env.APP_NAME }}/tests/install_no_init.py &
-#          echo $! > /tmp/_install.pid
-#          sleep 5s
-#          php occ app_api:daemon:register manual_install "Manual Install" manual-install 0 0 0
-#          php occ app_api:app:register nc_py_api manual_install --json-info \
-#            "{\"appid\":\"$APP_ID\",\"name\":\"$APP_ID\",\"daemon_config_name\":\"manual_install\",\"version\":\"$APP_VERSION\",\"secret\":\"$APP_SECRET\",\"host\":\"localhost\",\"port\":$APP_PORT,\"scopes\":{\"required\":[\"SYSTEM\", \"FILES\", \"FILES_SHARING\"],\"optional\":[\"USER_INFO\", \"USER_STATUS\", \"NOTIFICATIONS\", \"WEATHER_STATUS\", \"TALK\"]},\"protocol\":\"http\",\"system_app\":1}" \
-#            --force-scopes --wait-finish
-#          kill -15 $(cat /tmp/_install.pid)
-#          timeout 3m tail --pid=$(cat /tmp/_install.pid) -f /dev/null
-#
-#      - name: Upload NC logs
-#        if: always()
-#        uses: actions/upload-artifact@v3
-#        with:
-#          name: install_no_init.log
-#          path: data/nextcloud.log
-#          if-no-files-found: warn
-
   tests-special-success:
     permissions:
       contents: none
     runs-on: ubuntu-22.04
-    needs: [app-version-higher, no-init-endpoint]
+    needs: [app-version-higher, auth-tests-no-init]
     name: TestsSpecial-OK
     steps:
       - run: echo "Tests special passed successfully"

--- a/.github/workflows/tests-special.yml
+++ b/.github/workflows/tests-special.yml
@@ -259,7 +259,7 @@ jobs:
           timeout 3m tail --pid=$(cat /tmp/_install.pid) -f /dev/null
 
       - name: Test NO ALL Scope, NO System App
-        run: python3 apps/${{ env.APP_NAME }}/tests/auth_scopes_system.py 1
+        run: python3 apps/${{ env.APP_NAME }}/tests/auth_scopes_system.py 2
 
       - name: Upload NC logs
         if: always()

--- a/.github/workflows/tests-special.yml
+++ b/.github/workflows/tests-special.yml
@@ -220,7 +220,7 @@ jobs:
           sleep 5s
           php occ app_api:daemon:register manual_install "Manual Install" manual-install 0 0 0
           php occ app_api:app:register $APP_ID manual_install --json-info \
-            "{\"appid\":\"$APP_ID\",\"name\":\"$APP_ID\",\"daemon_config_name\":\"manual_install\",\"version\":\"$APP_VERSION\",\"secret\":\"$APP_SECRET\",\"host\":\"localhost\",\"port\":$APP_PORT,\"scopes\":{\"required\":[\"ALL\"],\"optional\":[]},\"protocol\":\"http\",\"system_app\":0}" \
+            "{\"appid\":\"$APP_ID\",\"name\":\"$APP_ID\",\"daemon_config_name\":\"manual_install\",\"version\":\"$APP_VERSION\",\"secret\":\"$APP_SECRET\",\"host\":\"localhost\",\"port\":$APP_PORT,\"scopes\":{\"required\":[\"ALL\"],\"optional\":[]},\"protocol\":\"http\",\"system_app\":1}" \
             --force-scopes --wait-finish
           kill -15 $(cat /tmp/_install.pid)
           timeout 3m tail --pid=$(cat /tmp/_install.pid) -f /dev/null
@@ -238,7 +238,7 @@ jobs:
           echo $! > /tmp/_install.pid
           sleep 5s
           php occ app_api:app:register $APP_ID manual_install --json-info \
-            "{\"appid\":\"$APP_ID\",\"name\":\"$APP_ID\",\"daemon_config_name\":\"manual_install\",\"version\":\"$APP_VERSION\",\"secret\":\"$APP_SECRET\",\"host\":\"localhost\",\"port\":$APP_PORT,\"scopes\":{\"required\":[\"SYSTEM\"],\"optional\":[]},\"protocol\":\"http\",\"system_app\":0}" \
+            "{\"appid\":\"$APP_ID\",\"name\":\"$APP_ID\",\"daemon_config_name\":\"manual_install\",\"version\":\"$APP_VERSION\",\"secret\":\"$APP_SECRET\",\"host\":\"localhost\",\"port\":$APP_PORT,\"scopes\":{\"required\":[\"SYSTEM\"],\"optional\":[]},\"protocol\":\"http\",\"system_app\":1}" \
             --force-scopes --wait-finish
           kill -15 $(cat /tmp/_install.pid)
           timeout 3m tail --pid=$(cat /tmp/_install.pid) -f /dev/null

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-## [1.4.5 - 202x-xx-xx]
+## [1.4.5 - 2024-01-02]
+
+### Added
+
+- Support for `ALL` API scope, that allows to call anyNextcloud endpoints bypassing API Scope check. #190
 
 ### Fixed
 
 - Fixed incorrect DeployConfig SSL params parsing. #188 (Thanks to @raudraido)
+- Incorrect HTTP status during invalid auth. #190
 
 ## [1.4.4 - 2023-12-21]
 

--- a/docs/tech_details/ApiScopes.rst
+++ b/docs/tech_details/ApiScopes.rst
@@ -20,18 +20,19 @@ but a subsequent version does, you can effortlessly specify the new API groups i
 
 The following API groups are currently supported:
 
-* ``2``   SYSTEM
-* ``10``  FILES
-* ``11``  FILES_SHARING
-* ``30``  USER_INFO
-* ``31``  USER_STATUS
-* ``32``  NOTIFICATIONS
-* ``33``  WEATHER_STATUS
-* ``50``  TALK
-* ``60``  TALK_BOT
-* ``61``  AI_PROVIDERS
-* ``110`` ACTIVITIES
-* ``120`` NOTES
+* ``2``     SYSTEM
+* ``10``    FILES
+* ``11``    FILES_SHARING
+* ``30``    USER_INFO
+* ``31``    USER_STATUS
+* ``32``    NOTIFICATIONS
+* ``33``    WEATHER_STATUS
+* ``50``    TALK
+* ``60``    TALK_BOT
+* ``61``    AI_PROVIDERS
+* ``110``   ACTIVITIES
+* ``120``   NOTES
+* ``9999``  ALL
 
 These groups are identified using names. As time progresses,
 the list will steadily expand, comprehensively encompassing all potential APIs provided by Nextcloud.

--- a/lib/Middleware/AppAPIAuthMiddleware.php
+++ b/lib/Middleware/AppAPIAuthMiddleware.php
@@ -37,10 +37,9 @@ class AppAPIAuthMiddleware extends Middleware {
 		$reflectionMethod = new ReflectionMethod($controller, $methodName);
 
 		$isAppAPIAuth = !empty($reflectionMethod->getAttributes(AppAPIAuth::class));
-
 		if ($isAppAPIAuth) {
 			if (!$this->service->validateExAppRequestToNC($this->request)) {
-				throw new AppAPIAuthNotValidException($this->l->t('AppAPIAuth authentication failed'), Http::STATUS_UNAUTHORIZED);
+				throw new AppAPIAuthNotValidException($this->l->t('AppAPI authentication failed'), Http::STATUS_UNAUTHORIZED);
 			}
 		}
 	}
@@ -57,15 +56,10 @@ class AppAPIAuthMiddleware extends Middleware {
 	 */
 	public function afterException($controller, $methodName, Exception $exception): Response {
 		if ($exception instanceof AppAPIAuthNotValidException) {
-			$response = new JSONResponse([
-				'message' => $exception->getMessage(),
-				$exception->getCode()
-			]);
 			$this->logger->debug($exception->getMessage(), [
 				'exception' => $exception,
-				$exception->getCode()
 			]);
-			return $response;
+			return new JSONResponse(['message' => $exception->getMessage()], $exception->getCode());
 		}
 
 		throw $exception;

--- a/lib/Service/AppAPIService.php
+++ b/lib/Service/AppAPIService.php
@@ -756,7 +756,7 @@ class AppAPIService {
 			}
 
 			// For APIs that not assuming work under user context we do not check ExApp users
-			if (($apiScope !== null) and ($apiScope->getUserCheck())) {
+			if (($apiScope === null) or ($apiScope->getUserCheck())) {
 				try {
 					if (!$this->exAppUsersService->exAppUserExists($exApp->getAppid(), $userId)) {
 						$this->logger->error(sprintf('ExApp %s user %s does not exist', $exApp->getAppid(), $userId));

--- a/lib/Service/AppAPIService.php
+++ b/lib/Service/AppAPIService.php
@@ -38,7 +38,6 @@ use Psr\Log\LoggerInterface;
 use SimpleXMLElement;
 
 class AppAPIService {
-	public const BASIC_API_SCOPE = 1;
 	public const CACHE_TTL = 60 * 60; // 1 hour
 
 	private ICache $cache;
@@ -737,21 +736,27 @@ class AppAPIService {
 			} else {
 				$path = '/dav/';
 			}
+
+			$allScopesFlag = (bool)$this->exAppScopesService->getByScope($exApp, ExAppApiScopeService::ALL_API_SCOPE);
 			$apiScope = $this->exAppApiScopeService->getApiScopeByRoute($path);
 
-			if ($apiScope === null) {
-				$this->logger->error(sprintf('Failed to check apiScope %s', $path));
-				return false;
-			}
-			// BASIC ApiScope is granted to all ExApps (all Api routes with BASIC scope group).
-			if ($apiScope->getScopeGroup() !== self::BASIC_API_SCOPE) {
-				if (!$this->exAppScopesService->passesScopeCheck($exApp, $apiScope->getScopeGroup())) {
-					$this->logger->error(sprintf('ExApp %s not passed scope group check %s', $exApp->getAppid(), $path));
+			if (!$allScopesFlag) {
+				if ($apiScope === null) {
+					$this->logger->error(sprintf('Failed to check apiScope %s', $path));
 					return false;
 				}
+
+				// BASIC ApiScope is granted to all ExApps (all API routes with BASIC scope group).
+				if ($apiScope->getScopeGroup() !== ExAppApiScopeService::BASIC_API_SCOPE) {
+					if (!$this->exAppScopesService->passesScopeCheck($exApp, $apiScope->getScopeGroup())) {
+						$this->logger->error(sprintf('ExApp %s not passed scope group check %s', $exApp->getAppid(), $path));
+						return false;
+					}
+				}
 			}
+
 			// For APIs that not assuming work under user context we do not check ExApp users
-			if ($apiScope->getUserCheck()) {
+			if (($apiScope !== null) and ($apiScope->getUserCheck())) {
 				try {
 					if (!$this->exAppUsersService->exAppUserExists($exApp->getAppid(), $userId)) {
 						$this->logger->error(sprintf('ExApp %s user %s does not exist', $exApp->getAppid(), $userId));

--- a/lib/Service/ExAppApiScopeService.php
+++ b/lib/Service/ExAppApiScopeService.php
@@ -119,7 +119,7 @@ class ExAppApiScopeService {
 			['api_route' => '/apps/notes/api/', 'scope_group' => 120, 'name' => 'NOTES', 'user_check' => 1],
 
 			//ALL Scope
-			['api_route' => 'non-exist-all-route-z', 'scope_group' => self::ALL_API_SCOPE, 'name' => 'ALL', 'user_check' => 1],
+			['api_route' => 'non-exist-all-api-route', 'scope_group' => self::ALL_API_SCOPE, 'name' => 'ALL', 'user_check' => 1],
 		];
 
 		$this->cache->clear('/all_api_scopes');

--- a/lib/Service/ExAppApiScopeService.php
+++ b/lib/Service/ExAppApiScopeService.php
@@ -16,6 +16,8 @@ use OCP\ICacheFactory;
 use Psr\Log\LoggerInterface;
 
 class ExAppApiScopeService {
+	public const BASIC_API_SCOPE = 1;
+	public const ALL_API_SCOPE = 9999;
 	private ICache $cache;
 
 	public function __construct(
@@ -115,6 +117,9 @@ class ExAppApiScopeService {
 			['api_route' => '/apps/spreed/api/', 'scope_group' => 50, 'name' => 'TALK', 'user_check' => 1],
 			['api_route' => '/apps/activity/api/', 'scope_group' => 110, 'name' => 'ACTIVITIES', 'user_check' => 1],
 			['api_route' => '/apps/notes/api/', 'scope_group' => 120, 'name' => 'NOTES', 'user_check' => 1],
+
+			//ALL Scope
+			['api_route' => 'non-exist-all-route-z', 'scope_group' => self::ALL_API_SCOPE, 'name' => 'ALL', 'user_check' => 1],
 		];
 
 		$this->cache->clear('/all_api_scopes');

--- a/tests/auth_scopes_system.py
+++ b/tests/auth_scopes_system.py
@@ -2,6 +2,9 @@ import sys
 import pytest
 import nc_py_api
 
+# sys.argv[1] = 0 -> System App, ALL Scope
+# sys.argv[1] = 1 -> System App, No ALL Scope
+# sys.argv[1] = 2 -> No System App, ALL Scope
 
 if __name__ == "__main__":
     nc = nc_py_api.NextcloudApp(user="admin")
@@ -12,4 +15,11 @@ if __name__ == "__main__":
         with pytest.raises(nc_py_api.NextcloudException) as e:
             nc.ocs("GET", "/ocs/v2.php/core/whatsnew")
         assert e.value.status_code == 401
-    assert nc.users_list()
+
+    if int(sys.argv[1]) == 2:
+        # as NextcloudApp was initialized with `user="admin"` this will fail for non-system app.
+        with pytest.raises(nc_py_api.NextcloudException) as e:
+            nc.users_list()
+        assert e.value.status_code == 401
+    else:
+        assert nc.users_list()

--- a/tests/auth_scopes_system.py
+++ b/tests/auth_scopes_system.py
@@ -7,9 +7,10 @@ if __name__ == "__main__":
     nc = nc_py_api.NextcloudApp(user="admin")
     assert nc.capabilities
     if int(sys.argv[1]) == 0:
-        assert nc.ocs("GET", "/ocs/v2.php/core/whatsnew")
+        nc.ocs("GET", "/ocs/v2.php/core/whatsnew")
     else:
         with pytest.raises(nc_py_api.NextcloudException) as e:
-            assert e.value.status_code == 401
+			nc.ocs("GET", "/ocs/v2.php/core/whatsnew")
+        assert e.value.status_code == 401
     assert nc.users_list()
     exit(0)

--- a/tests/auth_scopes_system.py
+++ b/tests/auth_scopes_system.py
@@ -1,0 +1,15 @@
+import sys
+import pytest
+import nc_py_api
+
+
+if __name__ == "__main__":
+    nc = nc_py_api.NextcloudApp()
+    assert nc.capabilities
+    if int(sys.argv[1]) == 0:
+        assert nc.ocs("GET", "/ocs/v2.php/core/whatsnew")
+    else:
+        with pytest.raises(nc_py_api.NextcloudException) as e:
+            assert e.value.status_code == 401
+    assert nc.users_list()
+    exit(0)

--- a/tests/auth_scopes_system.py
+++ b/tests/auth_scopes_system.py
@@ -4,7 +4,7 @@ import nc_py_api
 
 
 if __name__ == "__main__":
-    nc = nc_py_api.NextcloudApp()
+    nc = nc_py_api.NextcloudApp(user="admin")
     assert nc.capabilities
     if int(sys.argv[1]) == 0:
         assert nc.ocs("GET", "/ocs/v2.php/core/whatsnew")

--- a/tests/auth_scopes_system.py
+++ b/tests/auth_scopes_system.py
@@ -10,7 +10,6 @@ if __name__ == "__main__":
         nc.ocs("GET", "/ocs/v2.php/core/whatsnew")
     else:
         with pytest.raises(nc_py_api.NextcloudException) as e:
-			nc.ocs("GET", "/ocs/v2.php/core/whatsnew")
+            nc.ocs("GET", "/ocs/v2.php/core/whatsnew")
         assert e.value.status_code == 401
     assert nc.users_list()
-    exit(0)

--- a/tests/psalm-baseline.xml
+++ b/tests/psalm-baseline.xml
@@ -96,17 +96,6 @@
       <code>IEventListener</code>
     </MissingTemplateParam>
   </file>
-  <file src="lib/Middleware/AppAPIAuthMiddleware.php">
-    <TypeDoesNotContainType>
-      <code>$exception instanceof AppAPIAuth</code>
-    </TypeDoesNotContainType>
-    <UndefinedMethod>
-      <code>getCode</code>
-      <code>getMessage</code>
-      <code>getMessage</code>
-      <code>getMessage</code>
-    </UndefinedMethod>
-  </file>
   <file src="lib/Profiler/AppAPIDataCollector.php">
     <UndefinedClass>
       <code>Request</code>


### PR DESCRIPTION
Added `ALL` ApiScope to allow the use of OCS Apis that we have not yet defined in the AppAPI.

Also with help of https://github.com/cloud-py-api/app_api/pull/190/commits/993a1113512ad0fad8aef61fc04b22460a4f7ad3 AppAPI now correctly returns status **401** instead of **996** for Controllers protected by AppAPIAuth attribute.