### PR TITLE
occ app:register -> return error if specified invalid info-xml

### DIFF
--- a/lib/Command/ExApp/Register.php
+++ b/lib/Command/ExApp/Register.php
@@ -73,7 +73,8 @@ class Register extends Command {
 		if ($daemonConfig->getAcceptsDeployId() === $this->dockerActions->getAcceptsDeployId()) {
 			$exAppInfo = $this->dockerActions->loadExAppInfo($appId, $daemonConfig);
 			if (array_key_exists('error', $exAppInfo)) {
-				$output->writeln(sprintf('%sDid application was deployed before registration?', $exAppInfo['error']));
+				$output->writeln($exAppInfo['error']);
+				$output->writeln('Did application was deployed before registration?');
 				return 2;
 			}
 		} elseif ($daemonConfig->getAcceptsDeployId() === $this->manualActions->getAcceptsDeployId()) {
@@ -131,6 +132,10 @@ class Register extends Command {
 		$infoXml = null;
 		if ($pathToInfoXml !== null) {
 			$infoXml = simplexml_load_string(file_get_contents($pathToInfoXml));
+			if ($infoXml === false) {
+				$output->writeln(sprintf('Failed to load info.xml from %s', $pathToInfoXml));
+				return 2;
+			}
 		}
 
 		$requestedExAppScopeGroups = $this->service->getExAppRequestedScopes($exApp, $infoXml, $exAppInfo);


### PR DESCRIPTION
If the `php occ app_api:app:register ... --info-xml` parameter is specified, then we should return an error if the file is not available for the specified parameter, rather than silently ignoring it.

_This is small fix, as this is used only for development we do not mention it in changelog._

