### PR TITLE
remove double "daemonConfigService->unregisterDaemonConfig" call

### DIFF
--- a/lib/Command/Daemon/UnregisterDaemon.php
+++ b/lib/Command/Daemon/UnregisterDaemon.php
@@ -29,11 +29,6 @@ class UnregisterDaemon extends Command {
 
 		$daemonConfig = $this->daemonConfigService->getDaemonConfigByName($daemonConfigName);
 		if ($daemonConfig === null) {
-			$output->writeln('Daemon config not found.');
-			return 1;
-		}
-
-		if ($this->daemonConfigService->unregisterDaemonConfig($daemonConfig) === null) {
 			$output->writeln(sprintf('Daemon config %s not found.', $daemonConfigName));
 			return 1;
 		}


### PR DESCRIPTION
Looks like it was a typo during initial fast development, I did not find today any reason to perform a call

```php

$this->daemonConfigService->unregisterDaemonConfig($daemonConfig)

```

two times in a row.