### PR TITLE
getRegisteredDaemonConfigs: always return array

### DIFF
--- a/lib/Command/Daemon/ListDaemons.php
+++ b/lib/Command/Daemon/ListDaemons.php
@@ -29,11 +29,6 @@ class ListDaemons extends Command {
 
 	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$daemonConfigs = $this->daemonConfigService->getRegisteredDaemonConfigs();
-		if ($daemonConfigs === null) {
-			$output->writeln('<error>Failed to get list of daemons.</error>');
-			return 1;
-		}
-
 		if (count($daemonConfigs) === 0) {
 			$output->writeln('No registered daemon configs.');
 			return 0;

--- a/lib/Service/DaemonConfigService.php
+++ b/lib/Service/DaemonConfigService.php
@@ -70,9 +70,9 @@ class DaemonConfigService {
 	}
 
 	/**
-	 * @return DaemonConfig[]|null
+	 * @return DaemonConfig[]
 	 */
-	public function getRegisteredDaemonConfigs(): ?array {
+	public function getRegisteredDaemonConfigs(): array {
 		try {
 			$cacheKey = '/daemon_configs';
 			$cached = $this->cache->get($cacheKey);
@@ -86,8 +86,8 @@ class DaemonConfigService {
 			$this->cache->set($cacheKey, $daemonConfigs, self::CACHE_TTL);
 			return $daemonConfigs;
 		} catch (Exception $e) {
-			$this->logger->error('Failed to get registered daemon configs. Error: ' . $e->getMessage(), ['exception' => $e]);
-			return null;
+			$this->logger->debug('Failed to get registered daemon configs. Error: ' . $e->getMessage(), ['exception' => $e]);
+			return [];
 		}
 	}
 


### PR DESCRIPTION
Changed loglevel to debug(we should stick in all Services to loglevel `info` or `debug`).

It is used in 3 places, one place is already covered with log level, two more are in UI and it will visible in UI if returned array is empty.