### PR TITLE
delay userId querying from DI later in anonymous class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-## [1.4.6 - 2024-01-0x]
+## [1.4.6 - 2024-01-05]
 
 ### Fixed
 
 - TopMenuAPI: support of params in styles/js ExApp URLs. #193 (Thanks to @splitt3r)
+- NC28: FileActionsAPI wasn't working without specifying an icon. #198
+- Bug introduced in the previous version, when the `userId` for some part of AppAPI became `null`. #199
 
 ## [1.4.5 - 2024-01-02]
 

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -42,7 +42,7 @@ to join us in shaping a more versatile, stable, and secure app landscape.
 *Your insights, suggestions, and contributions are invaluable to us.*
 
 	]]></description>
-	<version>1.4.5</version>
+	<version>1.4.6</version>
 	<licence>agpl</licence>
 	<author mail="andrey18106x@gmail.com" homepage="https://github.com/andrey18106">Andrey Borysenko</author>
 	<author mail="bigcat88@icloud.com" homepage="https://github.com/bigcat88">Alexander Piskun</author>

--- a/lib/Service/SpeechToTextService.php
+++ b/lib/Service/SpeechToTextService.php
@@ -25,7 +25,6 @@ class SpeechToTextService {
 		ICacheFactory                               $cacheFactory,
 		private readonly SpeechToTextProviderMapper $mapper,
 		private readonly LoggerInterface            $logger,
-		private readonly ?string                    $userId,
 	) {
 		$this->cache = $cacheFactory->createDistributed(Application::APP_ID . '/ex_speech_to_text_providers');
 	}
@@ -146,14 +145,16 @@ class SpeechToTextService {
 	 * @psalm-suppress UndefinedClass, MissingDependency, InvalidReturnStatement, InvalidReturnType
 	 */
 	private function getAnonymousExAppProvider(SpeechToTextProvider $provider, IServerContainer $serverContainer, string $class): ?ISpeechToTextProviderWithId {
-		return new class($provider, $serverContainer, $this->userId, $class) implements ISpeechToTextProviderWithId {
+		return new class($provider, $serverContainer, $class) implements ISpeechToTextProviderWithId {
+			private ?string $userId;
+
 			public function __construct(
 				private SpeechToTextProvider $sttProvider,
 				// We need this to delay the instantiation of AppAPIService during registration to avoid conflicts
 				private IServerContainer     $serverContainer, // TODO: Extract needed methods from AppAPIService to be able to use it everytime
-				private readonly ?string     $userId,
 				private readonly string      $class,
 			) {
+				$this->userId = $this->serverContainer->get('userId');
 			}
 
 			public function getId(): string {

--- a/lib/Service/SpeechToTextService.php
+++ b/lib/Service/SpeechToTextService.php
@@ -154,7 +154,6 @@ class SpeechToTextService {
 				private IServerContainer     $serverContainer, // TODO: Extract needed methods from AppAPIService to be able to use it everytime
 				private readonly string      $class,
 			) {
-				$this->userId = $this->serverContainer->get('userId');
 			}
 
 			public function getId(): string {
@@ -203,6 +202,10 @@ class SpeechToTextService {
 					));
 				}
 				return $response->getBody();
+			}
+
+			public function setUserId(?string $userId): void {
+				$this->userId = $userId;
 			}
 		};
 	}

--- a/lib/Service/TextProcessingService.php
+++ b/lib/Service/TextProcessingService.php
@@ -32,7 +32,6 @@ class TextProcessingService {
 	public function __construct(
 		ICacheFactory                                 $cacheFactory,
 		private readonly TextProcessingProviderMapper $mapper,
-		private readonly ?string                      $userId,
 		private readonly LoggerInterface              $logger,
 	) {
 		$this->cache = $cacheFactory->createDistributed(Application::APP_ID . '/ex__text_processing_providers');
@@ -161,13 +160,15 @@ class TextProcessingService {
 		string $className,
 		IServerContainer $serverContainer
 	): IProviderWithId {
-		return new class($provider, $serverContainer, $className, $this->userId) implements IProviderWithId, IProviderWithUserId {
+		return new class($provider, $serverContainer, $className) implements IProviderWithId, IProviderWithUserId {
+			private ?string $userId;
+
 			public function __construct(
 				private readonly TextProcessingProvider $provider,
 				private readonly IServerContainer       $serverContainer,
 				private readonly string                 $className,
-				private ?string                         $userId,
 			) {
+				$this->userId = $this->serverContainer->get('userId');
 			}
 
 			public function getId(): string {

--- a/lib/Service/TextProcessingService.php
+++ b/lib/Service/TextProcessingService.php
@@ -168,7 +168,6 @@ class TextProcessingService {
 				private readonly IServerContainer       $serverContainer,
 				private readonly string                 $className,
 			) {
-				$this->userId = $this->serverContainer->get('userId');
 			}
 
 			public function getId(): string {


### PR DESCRIPTION
During PHP App registration process we don't have a complete session and other stuff queried from DI which is for some reason (I don't know why yet) breaks its usage later.