### PR TITLE
ExApp status: do not encode & decode with hands

### DIFF
--- a/lib/BackgroundJob/ExAppInitStatusCheckJob.php
+++ b/lib/BackgroundJob/ExAppInitStatusCheckJob.php
@@ -33,7 +33,7 @@ class ExAppInitStatusCheckJob extends TimedJob {
 			$exApps = $this->mapper->findAll();
 			$initTimeoutMinutes = intval($this->config->getAppValue(Application::APP_ID, 'ex_app_init_timeout', '40'));
 			foreach ($exApps as $exApp) {
-				$status = json_decode($exApp->getStatus(), true);
+				$status = $exApp->getStatus();
 				if (!isset($status['init_start_time'])) {
 					continue;
 				}

--- a/lib/Command/ExApp/Register.php
+++ b/lib/Command/ExApp/Register.php
@@ -192,7 +192,7 @@ class Register extends Command {
 		if ($waitFinish) {
 			do {
 				$exApp = $this->service->getExApp($appId);
-				$status = json_decode($exApp->getStatus(), true);
+				$status = $exApp->getStatus();
 				if (isset($status['error'])) {
 					$output->writeln(sprintf('ExApp %s initialization step failed. Error: %s', $appId, $status['error']));
 					return 1;

--- a/lib/Controller/ExAppsPageController.php
+++ b/lib/Controller/ExAppsPageController.php
@@ -255,7 +255,7 @@ class ExAppsPageController extends Controller {
 				'daemon' => $daemon,
 				'systemApp' => $exApp !== null && $this->exAppUsersService->exAppUserExists($exApp->getAppid(), ''),
 				'exAppUrl' => $exApp !== null ? AppAPIService::getExAppUrl($exApp->getProtocol(), $exApp->getHost(), $exApp->getPort()) : '',
-				'status' => $exApp !== null ? json_decode($exApp->getStatus(), true) : [],
+				'status' => $exApp !== null ? $exApp->getStatus() : [],
 			];
 		}
 
@@ -394,7 +394,7 @@ class ExAppsPageController extends Controller {
 					'exAppUrl' => AppAPIService::getExAppUrl($exApp->getProtocol(), $exApp->getHost(), $exApp->getPort()),
 					'releases' => [],
 					'update' => null,
-					'status' => json_decode($exApp->getStatus(), true),
+					'status' => $exApp->getStatus(),
 				];
 			}
 		}
@@ -471,7 +471,7 @@ class ExAppsPageController extends Controller {
 							'daemon_config' => $daemonConfig,
 							'systemApp' => $this->exAppUsersService->exAppUserExists($exApp->getAppid(), ''),
 							'exAppUrl' => AppAPIService::getExAppUrl($exApp->getProtocol(), $exApp->getHost(), $exApp->getPort()),
-							'status' => json_decode($exApp->getStatus(), true),
+							'status' => $exApp->getStatus(),
 							'scopes' => $scopes,
 						]
 					]);
@@ -735,7 +735,7 @@ class ExAppsPageController extends Controller {
 	 */
 	public function getAppStatus(string $appId): JSONResponse {
 		$exApp = $this->service->getExApp($appId);
-		return new JSONResponse(json_decode($exApp->getStatus(), true));
+		return new JSONResponse($exApp->getStatus());
 	}
 
 	/**

--- a/lib/Db/ExApp.php
+++ b/lib/Db/ExApp.php
@@ -20,7 +20,7 @@ use OCP\AppFramework\Db\Entity;
  * @method string getHost()
  * @method int getPort()
  * @method string getSecret()
- * @method string getStatus()
+ * @method array getStatus()
  * @method int getEnabled()
  * @method int getCreatedTime()
  * @method int getLastCheckTime()
@@ -32,7 +32,7 @@ use OCP\AppFramework\Db\Entity;
  * @method void setHost(string $host)
  * @method void setPort(int $port)
  * @method void setSecret(string $secret)
- * @method void setStatus(string $status)
+ * @method void setStatus(array $status)
  * @method void setEnabled(int $enabled)
  * @method void setCreatedTime(int $createdTime)
  * @method void setLastCheckTime(int $lastCheckTime)
@@ -63,7 +63,7 @@ class ExApp extends Entity implements JsonSerializable {
 		$this->addType('host', 'string');
 		$this->addType('port', 'int');
 		$this->addType('secret', 'string');
-		$this->addType('status', 'string');
+		$this->addType('status', 'json');
 		$this->addType('enabled', 'int');
 		$this->addType('createdTime', 'int');
 		$this->addType('lastCheckTime', 'int');

--- a/lib/Db/UI/InitialState.php
+++ b/lib/Db/UI/InitialState.php
@@ -16,7 +16,7 @@ use OCP\AppFramework\Db\Entity;
  * @method string getType()
  * @method string getName()
  * @method string getKey()
- * @method string getValue()
+ * @method array getValue()
  * @method void setAppid(string $appid)
  * @method void setType(string $type)
  * @method void setName(string $name)

--- a/lib/Service/AppAPIService.php
+++ b/lib/Service/AppAPIService.php
@@ -288,7 +288,7 @@ class AppAPIService {
 		$exApp = $this->getExApp($appId);
 		$cacheKey = '/exApp_' . $exApp->getAppid();
 
-		$status = json_decode($exApp->getStatus(), true);
+		$status = $exApp->getStatus();
 
 		if ($init) {
 			$status['init_start_time'] = time();
@@ -318,7 +318,7 @@ class AppAPIService {
 			}
 			$status['active'] = $progress === 100;
 		}
-		$exApp->setStatus(json_encode($status));
+		$exApp->setStatus($status);
 
 		try {
 			$exApp = $this->exAppMapper->update($exApp);
@@ -725,7 +725,7 @@ class AppAPIService {
 		if ($authValid) {
 			if (!$exApp->getEnabled()) {
 				// If ExApp is in initializing state, it is disabled yet, so we allow requests in such case
-				if (!isset(json_decode($exApp->getStatus(), true)['progress'])) {
+				if (!isset($exApp->getStatus()['progress'])) {
 					$this->logger->error(sprintf('ExApp with appId %s is disabled (%s)', $request->getHeader('EX-APP-ID'), $request->getRequestUri()));
 					return false;
 				}


### PR DESCRIPTION
ExApp.php:
```php
$this->addType('status', 'string');
```
->
```php
$this->addType('status', 'json');
```

In DB we already have this field marked as json.
