### PR TITLE
fixed errors found during installing on "Unraid"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [2.0.2 - 2024-01-28]
+
+### Fixed
+
+- More correct handling of the ExApps installation process when Nextcloud has a non-default directory location(e.g. `Unraid`). #217
+- Correct handling of the action of stopping a Docker container when the action is already in progress. #217
+- Correct handling of the ExApp deletion action, when during deletion you refresh the page and click delete again. #217
+
 ## [2.0.1 - 2024-01-25]
 
 ### Fixed

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -42,7 +42,7 @@ to join us in shaping a more versatile, stable, and secure app landscape.
 *Your insights, suggestions, and contributions are invaluable to us.*
 
 	]]></description>
-	<version>2.0.1</version>
+	<version>2.0.2</version>
 	<licence>agpl</licence>
 	<author mail="andrey18106x@gmail.com" homepage="https://github.com/andrey18106">Andrey Borysenko</author>
 	<author mail="bigcat88@icloud.com" homepage="https://github.com/bigcat88">Alexander Piskun</author>

--- a/lib/Controller/ExAppsPageController.php
+++ b/lib/Controller/ExAppsPageController.php
@@ -761,6 +761,9 @@ class ExAppsPageController extends Controller {
 	 */
 	public function getAppStatus(string $appId): JSONResponse {
 		$exApp = $this->exAppService->getExApp($appId);
+		if (is_null($exApp)) {
+			return new JSONResponse(['error' => $this->l10n->t('ExApp not found, failed to get status')], Http::STATUS_NOT_FOUND);
+		}
 		return new JSONResponse($exApp->getStatus());
 	}
 

--- a/lib/DeployActions/DockerActions.php
+++ b/lib/DeployActions/DockerActions.php
@@ -191,6 +191,9 @@ class DockerActions implements IDeployActions {
 			$response = $this->guzzleClient->delete($url);
 			return ['success' => $response->getStatusCode() === 204];
 		} catch (GuzzleException $e) {
+			if ($e->getCode() === 409) {  // "removal of container ... is already in progress"
+				return ['success' => true];
+			}
 			$this->logger->error('Failed to stop container', ['exception' => $e]);
 			error_log($e->getMessage());
 			return ['error' => 'Failed to stop container'];

--- a/lib/Service/ExAppService.php
+++ b/lib/Service/ExAppService.php
@@ -126,7 +126,7 @@ class ExAppService {
 				$this->cache->remove('/exApp_' . $appId);
 				return true;
 			}
-			$this->logger->error(sprintf('Error while unregistering %s ExApp from the database.', $appId));
+			$this->logger->warning(sprintf('Error while unregistering %s ExApp from the database.', $appId));
 		} catch (Exception $e) {
 			$this->logger->error(sprintf('Error while unregistering ExApp: %s', $e->getMessage()), ['exception' => $e]);
 		}


### PR DESCRIPTION
More correct handling of the ExApps installation process when Nextcloud has a non-default directory location(e.g. `Unraid`):

```php
$occDirectory = null;
if (!file_exists("console.php")) {
    $occDirectory = dirname(__FILE__, 5);
}
$this->logger->info(sprintf('Calling occ(directory=%s): %s', $occDirectory ?? 'null', $args));
$process = proc_open('php console.php ' . $args, $descriptors, $pipes, $occDirectory);
```

We first check if `occ` is available in the current directory, if yes, then we pass `null` to  proc_open.
On Unraid this works, as there half of Nextcloud directories are symlinks, and `occ` lives in current PHP directory, but not in the root of the Nextcloud.
Not sure how this will affect other installations, and will it break them or not, from what I see - it should not.

-------------

Correct handling of the action of stopping a Docker container when the action is already in progress:

```
ClientException Client error: `DELETE http://aa-docker-socket-proxy:2375/v1.41/containers/nc_app_ai_image_generator_bot` resulted in a `409 Conflict` response: {"message":"removal of container nc_app_ai_image_generator_bot is already in progress"}
```

```php
	public function removeContainer(string $dockerUrl, string $containerId): array {
		$url = $this->buildApiUrl($dockerUrl, sprintf('containers/%s', $containerId));
		try {
			$response = $this->guzzleClient->delete($url);
			return ['success' => $response->getStatusCode() === 204];
		} catch (GuzzleException $e) {
			if ($e->getCode() === 409) {  // "removal of container ... is already in progress"
				return ['success' => true];
			}
			$this->logger->error('Failed to stop container', ['exception' => $e]);
			error_log($e->getMessage());
			return ['error' => 'Failed to stop container'];
		}
	}

```	

-------------

Correct handling of the ExApp deletion action, when during deletion you refresh the page and click delete again:

```php

	public function getAppStatus(string $appId): JSONResponse {
		$exApp = $this->exAppService->getExApp($appId);
		if (is_null($exApp)) {
			return new JSONResponse(['error' => $this->l10n->t('ExApp not found, failed to get status')], Http::STATUS_NOT_FOUND);
		}
		return new JSONResponse($exApp->getStatus());
	}
```

Here we return an error to the UI when the ExApp is not found, instead of just throwing an unhandled exception.