### PR TITLE
occ:app_api:app:deploy - remove `-e` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [2.x.x - 2024-02-xx]
+
+### Changed
+
+- Removed not needed `-e` parameter for `occ:app_api:app:deploy`. #
+
 ## [2.0.3 - 2024-02-01]
 
 ### Added

--- a/docs/ManagingExternalApplications.rst
+++ b/docs/ManagingExternalApplications.rst
@@ -25,7 +25,7 @@ There are several commands to work with ExApps:
 Deploy
 ------
 
-Command: ``app_api:app:deploy [--info-xml INFO-XML] [-e|--env ENV] [--] <appid> <daemon-config-name>``
+Command: ``app_api:app:deploy [--info-xml INFO-XML] [--] <appid> <daemon-config-name>``
 
 The deploy command is the first ExApp installation step.
 
@@ -39,7 +39,6 @@ Options
 *******
 
     * ``--info-xml INFO-XML`` **[required]** - path to info.xml file (url or local absolute path)
-    * ``-e|--env ENV`` *[optional]* - additional environment variables (e.g. ``-e "MY_VAR=123" -e "MY_VAR2=456"``)
 
 Register
 --------

--- a/docs/tech_details/Deployment.rst
+++ b/docs/tech_details/Deployment.rst
@@ -67,7 +67,7 @@ This can be done by ``occ`` CLI command **app_api:app:deploy**:
 
 .. code-block:: bash
 
-	app_api:app:deploy <appid> <daemon-config-name> [--info-xml INFO-XML] [-e|--env ENV] [--]
+	app_api:app:deploy <appid> <daemon-config-name> [--info-xml INFO-XML] [--]
 
 .. note::
 	For development this step is skipped, as ExApp is deployed and started manually by developer.
@@ -85,7 +85,6 @@ Options
 *******
 
 	* ``--info-xml INFO-XML`` **[required]** - path to info.xml file (url or local absolute path)
-	* ``-e|--env ENV`` *[optional]* - additional environment variables (e.g. ``-e "MY_VAR=123" -e "MY_VAR2=456"``)
 
 Deploy result JSON
 ******************

--- a/lib/Command/ExApp/Deploy.php
+++ b/lib/Command/ExApp/Deploy.php
@@ -37,7 +37,6 @@ class Deploy extends Command {
 		$this->addArgument('daemon-config-name', InputArgument::OPTIONAL);
 
 		$this->addOption('info-xml', null, InputOption::VALUE_REQUIRED, '[required] Path to ExApp info.xml file (url or local absolute path)');
-		$this->addOption('env', 'e', InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Docker container environment variables', []);
 	}
 
 	protected function execute(InputInterface $input, OutputInterface $output): int {
@@ -76,11 +75,7 @@ class Deploy extends Command {
 			return 2;
 		}
 
-		$envParams = $input->getOption('env');
-
-		$deployParams = $this->dockerActions->buildDeployParams($daemonConfig, $infoXml, [
-			'env_options' => $envParams,
-		]);
+		$deployParams = $this->dockerActions->buildDeployParams($daemonConfig, $infoXml);
 
 		[$pullResult, $createResult, $startResult] = $this->dockerActions->deployExApp($daemonConfig, $deployParams);
 

--- a/lib/DeployActions/DockerActions.php
+++ b/lib/DeployActions/DockerActions.php
@@ -371,7 +371,7 @@ class DockerActions implements IDeployActions {
 			'storage' => $storage,
 			'system_app' => filter_var((string) $infoXml->xpath('external-app/system')[0], FILTER_VALIDATE_BOOLEAN),
 			'secret' => $secret ?? $this->random->generate(128),
-		], $params['env_options'] ?? [], $deployConfig);
+		], $deployConfig);
 
 		$containerParams = [
 			'name' => $appId,
@@ -400,7 +400,7 @@ class DockerActions implements IDeployActions {
 		return $deployEnvs;
 	}
 
-	public function buildDeployEnvs(array $params, array $envOptions, array $deployConfig): array {
+	public function buildDeployEnvs(array $params, array $deployConfig): array {
 		$autoEnvs = [
 			sprintf('AA_VERSION=%s', $this->appManager->getAppVersion(Application::APP_ID, false)),
 			sprintf('APP_SECRET=%s', $params['secret']),
@@ -418,14 +418,6 @@ class DockerActions implements IDeployActions {
 		if (isset($deployConfig['gpu']) && filter_var($deployConfig['gpu'], FILTER_VALIDATE_BOOLEAN)) {
 			$autoEnvs[] = sprintf('NVIDIA_VISIBLE_DEVICES=%s', 'all');
 			$autoEnvs[] = sprintf('NVIDIA_DRIVER_CAPABILITIES=%s', 'compute,utility');
-		}
-
-		foreach ($envOptions as $envOption) {
-			[$key, $value] = explode('=', $envOption, 2);
-			// Do not overwrite required auto generated envs
-			if (!in_array($key, DockerActions::AE_REQUIRED_ENVS, true)) {
-				$autoEnvs[] = sprintf('%s=%s', $key, $value);
-			}
 		}
 
 		return $autoEnvs;

--- a/lib/DeployActions/IDeployActions.php
+++ b/lib/DeployActions/IDeployActions.php
@@ -52,12 +52,11 @@ interface IDeployActions {
 	 * Build required deploy environment variables
 	 *
 	 * @param array $params
-	 * @param array $envOptions
 	 * @param array $deployConfig
 	 *
 	 * @return mixed
 	 */
-	public function buildDeployEnvs(array $params, array $envOptions, array $deployConfig): array;
+	public function buildDeployEnvs(array $params, array $deployConfig): array;
 
 	/**
 	 * Load ExApp information from the target daemon.

--- a/lib/DeployActions/ManualActions.php
+++ b/lib/DeployActions/ManualActions.php
@@ -33,7 +33,7 @@ class ManualActions implements IDeployActions {
 		return null;
 	}
 
-	public function buildDeployEnvs(array $params, array $envOptions, array $deployConfig): array {
+	public function buildDeployEnvs(array $params, array $deployConfig): array {
 		// Not implemented. Deploy is done manually.
 		return [];
 	}


### PR DESCRIPTION
All applications should, if they need to change their behavior depending on the config values in the Nextcloud, and not custom environment variables which we do not have the ability to set from the UI.

Let's remove this, because... it has never been used anywhere, and it is not at all clear why it was added..