### PR TITLE
removed check for "enable" state in OCS "log"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
-- Removed not needed `-e` parameter for `occ:app_api:app:deploy`. #
+- Removed not needed `-e` parameter for `occ:app_api:app:deploy`. #222
+
+### Fixed
+
+- OCS API `log` always fail during ExApp `init` state. #224
 
 ## [2.0.3 - 2024-02-01]
 

--- a/lib/Controller/OCSApiController.php
+++ b/lib/Controller/OCSApiController.php
@@ -43,14 +43,8 @@ class OCSApiController extends OCSController {
 	#[NoCSRFRequired]
 	public function log(int $level, string $message): DataResponse {
 		try {
-			$appId = $this->request->getHeader('EX-APP-ID');
-			$exApp = $this->exAppService->getExApp($appId);
-			if ($exApp === null) {
-				$this->logger->error('ExApp ' . $appId . ' not found');
-				throw new OCSBadRequestException('ExApp not found');
-			}
 			$this->logger->log($level, $message, [
-				'app' => $appId,
+				'app' => $this->request->getHeader('EX-APP-ID'),
 			]);
 			return new DataResponse();
 		} catch (InvalidArgumentException) {

--- a/lib/Controller/OCSApiController.php
+++ b/lib/Controller/OCSApiController.php
@@ -49,11 +49,6 @@ class OCSApiController extends OCSController {
 				$this->logger->error('ExApp ' . $appId . ' not found');
 				throw new OCSBadRequestException('ExApp not found');
 			}
-			$exAppEnabled = $exApp->getEnabled();
-			if ($exAppEnabled !== 1) {
-				$this->logger->error('ExApp ' . $appId . ' is disabled');
-				throw new OCSBadRequestException('ExApp is disabled');
-			}
 			$this->logger->log($level, $message, [
 				'app' => $appId,
 			]);


### PR DESCRIPTION
We do not need it, as it is covered by `AppAPIAuth` already with correct checking for status['progress'] value.