### PR TITLE
Optimize work with caches (AI providers)

### DIFF
--- a/lib/Db/SpeechToText/SpeechToTextProviderMapper.php
+++ b/lib/Db/SpeechToText/SpeechToTextProviderMapper.php
@@ -24,14 +24,9 @@ class SpeechToTextProviderMapper extends QBMapper {
 	 */
 	public function findAllEnabled(): array {
 		$qb = $this->db->getQueryBuilder();
-		$result = $qb->select(
-			'ex_speech_to_text.appid',
-			'ex_speech_to_text.name',
-			'ex_speech_to_text.display_name',
-			'ex_speech_to_text.action_handler',
-		)
-			->from($this->tableName, 'ex_speech_to_text')
-			->innerJoin('ex_speech_to_text', 'ex_apps', 'exa', 'exa.appid = ex_speech_to_text.appid')
+		$result = $qb->select('exs.*')
+			->from($this->tableName, 'exs')
+			->innerJoin('exs', 'ex_apps', 'exa', 'exa.appid = exs.appid')
 			->where(
 				$qb->expr()->eq('exa.enabled', $qb->createNamedParameter(1, IQueryBuilder::PARAM_INT))
 			)

--- a/lib/Db/TextProcessing/TextProcessingProviderMapper.php
+++ b/lib/Db/TextProcessing/TextProcessingProviderMapper.php
@@ -24,15 +24,9 @@ class TextProcessingProviderMapper extends QBMapper {
 	 */
 	public function findAllEnabled(): array {
 		$qb = $this->db->getQueryBuilder();
-		$result = $qb->select(
-			'ex_text_processing.appid',
-			'ex_text_processing.name',
-			'ex_text_processing.display_name',
-			'ex_text_processing.action_handler',
-			'ex_text_processing.task_type',
-		)
-			->from($this->tableName, 'ex_text_processing')
-			->innerJoin('ex_text_processing', 'ex_apps', 'exa', 'exa.appid = ex_text_processing.appid')
+		$result = $qb->select('exs.*')
+			->from($this->tableName, 'exs')
+			->innerJoin('exs', 'ex_apps', 'exa', 'exa.appid = exs.appid')
 			->where(
 				$qb->expr()->eq('exa.enabled', $qb->createNamedParameter(1, IQueryBuilder::PARAM_INT))
 			)->executeQuery();

--- a/lib/Db/Translation/TranslationProviderMapper.php
+++ b/lib/Db/Translation/TranslationProviderMapper.php
@@ -24,16 +24,9 @@ class TranslationProviderMapper extends QBMapper {
 	 */
 	public function findAllEnabled(): array {
 		$qb = $this->db->getQueryBuilder();
-		$result = $qb->select(
-			'ex_translation.appid',
-			'ex_translation.name',
-			'ex_translation.display_name',
-			'ex_translation.from_languages',
-			'ex_translation.to_languages',
-			'ex_translation.action_handler',
-		)
-			->from($this->tableName, 'ex_translation')
-			->innerJoin('ex_translation', 'ex_apps', 'exa', 'exa.appid = ex_translation.appid')
+		$result = $qb->select('exs.*')
+			->from($this->tableName, 'exs')
+			->innerJoin('exs', 'ex_apps', 'exa', 'exa.appid = exs.appid')
 			->where(
 				$qb->expr()->eq('exa.enabled', $qb->createNamedParameter(1, IQueryBuilder::PARAM_INT))
 			)
@@ -45,10 +38,10 @@ class TranslationProviderMapper extends QBMapper {
 	 * @param string $appId
 	 * @param string $name
 	 *
+	 * @return TranslationProvider
+	 * @throws DoesNotExistException
 	 * @throws Exception
 	 * @throws MultipleObjectsReturnedException
-	 *
-	 * @throws DoesNotExistException
 	 */
 	public function findByAppidName(string $appId, string $name): TranslationProvider {
 		$qb = $this->db->getQueryBuilder();


### PR DESCRIPTION
We don't need to have 2 caches for each provider, we only need one cache with the list enabled.

The cache with the general list was removed, as it is used only in the OCS API, which are called very rarely, and there it is not necessary, we will use caches only in those places where the execution time is critical (UI, internal APIs that are often called)

_Redis/ACPU will use less memory and overall this approach will be faster and less code_