### PR TITLE
reset "Error state" during Updating/Enabling of ExApp

### DIFF
--- a/lib/Command/ExApp/Update.php
+++ b/lib/Command/ExApp/Update.php
@@ -108,6 +108,7 @@ class Update extends Command {
 
 		$status = $exApp->getStatus();
 		$status['type'] = 'update';
+		$status['error'] = '';
 		$exApp->setStatus($status);
 		$this->exAppService->updateExApp($exApp);
 

--- a/lib/Service/AppAPIService.php
+++ b/lib/Service/AppAPIService.php
@@ -561,7 +561,7 @@ class AppAPIService {
 			if ($progress === 0) {
 				$status['action'] = 'init';
 				$status['init_start_time'] = time();
-				unset($status['error']);
+				$status['error'] = '';
 			}
 			$status['init'] = $progress;
 		}

--- a/lib/Service/ExAppService.php
+++ b/lib/Service/ExAppService.php
@@ -332,7 +332,7 @@ class ExAppService {
 			if ($progress === 0) {
 				$status['action'] = 'deploy';
 				$status['deploy_start_time'] = time();
-				unset($status['error']);
+				$status['error'] = '';
 			}
 			$status['deploy'] = $progress;
 		}
@@ -349,7 +349,7 @@ class ExAppService {
 		do {
 			$exApp = $this->getExApp($appId);
 			$status = $exApp->getStatus();
-			if (isset($status['error'])) {
+			if (isset($status['error']) && $status['error'] !== '') {
 				return sprintf('ExApp %s initialization step failed. Error: %s', $appId, $status['error']);
 			}
 			usleep(100000); // 0.1s

--- a/lib/Service/ExAppService.php
+++ b/lib/Service/ExAppService.php
@@ -84,7 +84,7 @@ class ExAppService {
 			'daemon_config_name' => $appInfo['daemon_config_name'],
 			'port' => $appInfo['port'],
 			'secret' => $appInfo['secret'],
-			'status' => json_encode(['deploy' => 0, 'init' => 0, 'action' => '', 'type' => 'install']),
+			'status' => json_encode(['deploy' => 0, 'init' => 0, 'action' => '', 'type' => 'install', 'error' => '']),
 			'created_time' => time(),
 			'last_check_time' => time(),
 		]);
@@ -145,6 +145,9 @@ class ExAppService {
 
 	public function enableExAppInternal(ExApp $exApp): bool {
 		$exApp->setEnabled(1);
+		$status = $exApp->getStatus();
+		$status['error'] = '';
+		$exApp->setStatus($status);
 		$result = $this->updateExApp($exApp);
 		$this->resetCaches();
 		return $result;


### PR DESCRIPTION
This will fix situations when ExApp after update or enabling work without errors, but state of previous error is still in DB and UI displays an error when all is already ok.

Also now we set 'error'(empty) always be present in "status" to allow us in future not check for it presence.