### PR TITLE
`exAppRequestWithUserInit` can accept empty `userId`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2.2.0 - 2024-02-21]
+
+### Added
+
+- Support of `L10N` translations for ExApps. #227
+
+### Fixed
+
+- Allowed removing of ExApp from UI during "init" stage. #235
+- Reset of "Error" state for ExApp in Update/Enable actions. #236
+- PublicFunctions.php: `exAppRequestWithUserInit` can accept empty `userId`. #238
+
 ## [2.1.0 - 2024-02-19]
 
 ### Changed

--- a/lib/PublicFunctions.php
+++ b/lib/PublicFunctions.php
@@ -42,7 +42,7 @@ class PublicFunctions {
 	public function exAppRequestWithUserInit(
 		string $appId,
 		string $route,
-		string $userId,
+		?string $userId = null,
 		string $method = 'POST',
 		array $params = [],
 		array $options = [],

--- a/lib/Service/AppAPIService.php
+++ b/lib/Service/AppAPIService.php
@@ -58,7 +58,7 @@ class AppAPIService {
 	public function aeRequestToExApp(
 		ExApp $exApp,
 		string $route,
-		string $userId,
+		?string $userId = null,
 		string $method = 'POST',
 		array $params = [],
 		array $options = [],


### PR DESCRIPTION
subj, we introduce it in AppAPI 2.0.0