### PR TITLE
Save user specified daemon host when using manual install

### DIFF
--- a/src/components/DaemonConfig/RegisterDaemonConfigModal.vue
+++ b/src/components/DaemonConfig/RegisterDaemonConfigModal.vue
@@ -330,7 +330,7 @@ export default {
 				display_name: this.displayName,
 				accepts_deploy_id: this.acceptsDeployId,
 				protocol: this.acceptsDeployId === 'docker-install' ? this.daemonProtocol : 'http',
-				host: this.acceptsDeployId === 'docker-install' ? this.host : 'host.docker.internal',
+				host: this.host,
 				deploy_config: {
 					net: this.deployConfig.net,
 					nextcloud_url: this.nextcloud_url,


### PR DESCRIPTION
At least for manual install, currently, a custom host is not saved as the front-end overwrites it which is quite confusing. 'host.docker.internal' is not resolvable under a Linux install of docker by default so it might make sense to not enforce this as a default setting in any case.