### PR TITLE
Check for AppAPI Auth header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Fixed
 
-- Added missing check for the presence of a header for AppAPI authentication, which could lead to increased load on the server. #250
+- Added missing check for the presence of a header for AppAPI authentication, which could lead to increased load on the server. #251
+- Bump follow-redirects package from `1.15.5` to `1.15.6` #250
 
 ## [2.3.0 - 2024-03-13]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [2.3.1 - 2024-03-2x]
+## [2.3.1 - 2024-03-18]
 
 ## Added 
 
 - `TEXT_PROCESSING` and `MACHINE_TRANSLATION` API scopes. #249
+
+## Fixed
+
+- Added missing check for the presence of a header for AppAPI authentication, which could lead to increased load on the server. #250
 
 ## [2.3.0 - 2024-03-13]
 

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -43,7 +43,7 @@ to join us in shaping a more versatile, stable, and secure app landscape.
 *Your insights, suggestions, and contributions are invaluable to us.*
 
 	]]></description>
-	<version>2.3.0</version>
+	<version>2.3.1</version>
 	<licence>agpl</licence>
 	<author mail="andrey18106x@gmail.com" homepage="https://github.com/andrey18106">Andrey Borysenko</author>
 	<author mail="bigcat88@icloud.com" homepage="https://github.com/bigcat88">Alexander Piskun</author>

--- a/lib/Middleware/AppAPIAuthMiddleware.php
+++ b/lib/Middleware/AppAPIAuthMiddleware.php
@@ -38,6 +38,9 @@ class AppAPIAuthMiddleware extends Middleware {
 
 		$isAppAPIAuth = !empty($reflectionMethod->getAttributes(AppAPIAuth::class));
 		if ($isAppAPIAuth) {
+			if (!$this->request->getHeader('AUTHORIZATION-APP-API')) {
+				throw new AppAPIAuthNotValidException($this->l->t('AppAPI authentication failed'), Http::STATUS_UNAUTHORIZED);
+			}
 			if (!$this->service->validateExAppRequestToNC($this->request)) {
 				throw new AppAPIAuthNotValidException($this->l->t('AppAPI authentication failed'), Http::STATUS_UNAUTHORIZED);
 			}

--- a/lib/Service/AppAPIService.php
+++ b/lib/Service/AppAPIService.php
@@ -168,7 +168,11 @@ class AppAPIService {
 	public function validateExAppRequestToNC(IRequest $request, bool $isDav = false): bool {
 		$this->throttler->sleepDelayOrThrowOnMax($request->getRemoteAddress(), Application::APP_ID);
 
-		$exApp = $this->exAppService->getExApp($request->getHeader('EX-APP-ID'));
+		$exAppId = $request->getHeader('EX-APP-ID');
+		if (!$exAppId) {
+			return false;
+		}
+		$exApp = $this->exAppService->getExApp($exAppId);
 		if ($exApp === null) {
 			$this->logger->error(sprintf('ExApp with appId %s not found.', $request->getHeader('EX-APP-ID')));
 			// Protection for guessing installed ExApps list

--- a/lib/Service/ExAppService.php
+++ b/lib/Service/ExAppService.php
@@ -68,10 +68,7 @@ class ExAppService {
 			$exApp = $this->exAppMapper->findByAppId($appId);
 			$this->cache->set($cacheKey, $exApp, self::CACHE_TTL);
 			return $exApp;
-		} catch (Exception | MultipleObjectsReturnedException | DoesNotExistException $e) {
-			$this->logger->debug(
-				sprintf('Failed to get ExApp %s. Error: %s', $appId, $e->getMessage()), ['exception' => $e]
-			);
+		} catch (Exception | MultipleObjectsReturnedException | DoesNotExistException) {
 		}
 		return null;
 	}


### PR DESCRIPTION
1. In `AppAPIAuthMiddleware` we should check for `AUTHORIZATION-APP-API` header to not first perform request to DB.
2. In `validateExAppRequestToNC` we should do the same but for 'EX-APP-ID' header.
3. Removed debug log from `getExApp`, to not spam logs.