### PR TITLE
added "all" and "showonly" flags to occ app:update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [2.3.2 - 2024-03-26]
+## [2.3.2 - 2024-03-28]
+
+### Added
+
+- `--all` and `--showonly` flags to `occ app_api:app:update` command. #256
 
 ### Fixed
 


### PR DESCRIPTION
They do almost the same like the original flags from Server repo with one difference:

`--showonly` flag can be specified only with `--all` flag.

We can not easy  make `--showonly` work for specified appid, cause we support updating ExApps with specifyng `json` or `xml` and not only by `appid`.