### PR TITLE
secrets appear on errors in logfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - Corrected error handling for `occ` commands: `register` and `update`. #258
+- `SensitiveParameter` is applied to variables containing secrets, preventing them from being leaked to the logs. #261
 
 ## [2.3.2 - 2024-03-28]
 


### PR DESCRIPTION
With PHP>=8.2 they will appear like this:

```
/var/www/html/apps-extra/app_api/lib/Service/AppAPIService.php
line 89
OCA\AppAPI\Service\AppAPIService->requestToExAppInternal(
  [
    "OCA\\AppAPI\\Db\\ExApp",
    3
  ],
  "POST",
  "http://host.docker.internal:9031/video_to_gif",
  [
    "SensitiveParameterValue"
  ]
)
```

Also adjustments in the Nextcloud Server required, to hide headers in `IClient` calls, we cannot do it from AppAPI side.