### PR TITLE
fix: do not spam error, do not rewrite previous error

### DIFF
--- a/lib/BackgroundJob/ExAppInitStatusCheckJob.php
+++ b/lib/BackgroundJob/ExAppInitStatusCheckJob.php
@@ -38,7 +38,7 @@ class ExAppInitStatusCheckJob extends TimedJob {
 					if (!isset($status['init_start_time'])) {
 						continue;
 					}
-					if (time() >= ($status['init_start_time'] + $initTimeoutMinutes * 60)) {
+					if ((time() >= ($status['init_start_time'] + $initTimeoutMinutes * 60)) && (empty($status['error']))) {
 						$this->service->setAppInitProgress(
 							$exApp, 0, sprintf('ExApp %s initialization timed out (%sm)', $exApp->getAppid(), $initTimeoutMinutes * 60)
 						);


### PR DESCRIPTION
1. Removes spam about the same error every 5 minutes
2. If there is already some kind of error there, then do not overwrite it and do nothing