### PR TITLE
initial support for Docker Healthcheck

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [2.5.0 - 2024-04-1x]
+## [2.5.0 - 2024-04-23]
 
 ### Added
 
 - Different compute device configuration for Daemon (NVIDIA, AMD, CPU). #267
 - Ability to add optional parameters when registering a daemon, for example *OVERRIDE_APP_HOST*. #269
+- Correct support of the Docker `HEALTHCHECK` instruction. #273
 
 ### Fixed
 

--- a/css/settings.css
+++ b/css/settings.css
@@ -348,7 +348,6 @@
 
 .apps-list.installed .actions .icon-loading-small {
 	display: inline-block;
-	top: 4px;
 	margin-right: 10px
 }
 

--- a/lib/Command/ExApp/Register.php
+++ b/lib/Command/ExApp/Register.php
@@ -185,7 +185,7 @@ class Register extends Command {
 				return 1;
 			}
 
-			if (!$this->dockerActions->healthcheckContainer($this->dockerActions->buildExAppContainerName($appId), $daemonConfig)) {
+			if (!$this->dockerActions->healthcheckContainer($this->dockerActions->buildExAppContainerName($appId), $daemonConfig, true)) {
 				$this->logger->error(sprintf('ExApp %s deployment failed. Error: %s', $appId, 'Container healthcheck failed.'));
 				if ($outputConsole) {
 					$output->writeln(sprintf('ExApp %s deployment failed. Error: %s', $appId, 'Container healthcheck failed.'));

--- a/lib/Command/ExApp/Update.php
+++ b/lib/Command/ExApp/Update.php
@@ -196,7 +196,7 @@ class Update extends Command {
 				return 1;
 			}
 
-			if (!$this->dockerActions->healthcheckContainer($this->dockerActions->buildExAppContainerName($appId), $daemonConfig)) {
+			if (!$this->dockerActions->healthcheckContainer($this->dockerActions->buildExAppContainerName($appId), $daemonConfig, true)) {
 				$this->logger->error(sprintf('ExApp %s update failed. Error: %s', $appId, 'Container healthcheck failed.'));
 				if ($outputConsole) {
 					$output->writeln(sprintf('ExApp %s update failed. Error: %s', $appId, 'Container healthcheck failed.'));

--- a/lib/Service/ExAppService.php
+++ b/lib/Service/ExAppService.php
@@ -312,7 +312,7 @@ class ExAppService {
 		}
 		unset($status['active']);  # TO-DO: Remove in AppAPI 2.4.0
 		if ($progress === 100) {
-			$status['action'] = '';
+			$status['action'] = 'healthcheck';
 		}
 		$exApp->setStatus($status);
 		$exApp->setLastCheckTime(time());

--- a/src/mixins/AppManagement.js
+++ b/src/mixins/AppManagement.js
@@ -32,7 +32,7 @@ export default {
 				return t('app_api', '{progress}% Initializing', { progress: this.app.status?.init })
 			}
 			if (this.app && Object.hasOwn(this.app?.status, 'action') && this.app.status.action === 'healthcheck') {
-				return t('app_api', 'Healthcheck')
+				return t('app_api', 'Healthchecking')
 			}
 			if (this.app.needsDownload) {
 				return t('app_api', 'Deploy and Enable')
@@ -47,7 +47,7 @@ export default {
 				return t('app_api', '{progress}% Initializing', { progress: this.app.status?.init })
 			}
 			if (this.app && Object.hasOwn(this.app?.status, 'action') && this.app.status.action === 'healthcheck') {
-				return t('app_api', 'Healthcheck')
+				return t('app_api', 'Healthchecking')
 			}
 			return t('app_api', 'Disable')
 		},

--- a/src/mixins/AppManagement.js
+++ b/src/mixins/AppManagement.js
@@ -10,7 +10,7 @@ export default {
 			return this.app && this.$store.getters.loading(this.app.id)
 		},
 		isInitializing() {
-			return this.app && Object.hasOwn(this.app?.status, 'action') && this.app.status.action === 'init'
+			return this.app && Object.hasOwn(this.app?.status, 'action') && (this.app.status.action === 'init' || this.app.status.action === 'healthcheck')
 		},
 		isDeploying() {
 			return this.app && Object.hasOwn(this.app?.status, 'action') && this.app.status.action === 'deploy'
@@ -31,6 +31,9 @@ export default {
 			if (this.app && Object.hasOwn(this.app?.status, 'action') && this.app.status.action === 'init') {
 				return t('app_api', '{progress}% Initializing', { progress: this.app.status?.init })
 			}
+			if (this.app && Object.hasOwn(this.app?.status, 'action') && this.app.status.action === 'healthcheck') {
+				return t('app_api', 'Healthcheck')
+			}
 			if (this.app.needsDownload) {
 				return t('app_api', 'Deploy and Enable')
 			}
@@ -42,6 +45,9 @@ export default {
 			}
 			if (this.app && Object.hasOwn(this.app?.status, 'action') && this.app.status.action === 'init') {
 				return t('app_api', '{progress}% Initializing', { progress: this.app.status?.init })
+			}
+			if (this.app && Object.hasOwn(this.app?.status, 'action') && this.app.status.action === 'healthcheck') {
+				return t('app_api', 'Healthcheck')
 			}
 			return t('app_api', 'Disable')
 		},

--- a/src/store/apps.js
+++ b/src/store/apps.js
@@ -200,7 +200,7 @@ const getters = {
 	},
 	getInitializingOrDeployingApps(state) {
 		return state.apps.filter(app => Object.hasOwn(app.status, 'action')
-			&& (app.status.action === 'deploy' || app.status.action === 'init')
+			&& (app.status.action === 'deploy' || app.status.action === 'init' || app.status.action === 'healthcheck')
 			&& app.status.type !== '')
 	},
 }


### PR DESCRIPTION
Before this, we didn’t have a `healthcheck` at all, but instead there was simply a check to see if the container was running.

Checking whether the container is running has been moved to Deploy stage and now occurs at the end of the deployment process.
And between deployment and “init” there is now a correct health check.
Applications are not required to support healthcheck at all, so it is only checked if `['State']['Health']['Status']` is present.

Without a timeout, the timeout must be set by the application itself, as it is usually done for Docker containers healthcheck.

During a healthcheck, an application, for example, can now install some of its own packages or do something other with its docker container.

It should not communicate with the Nextcloud itself at this stage(healthcheck), because application is not considered enabled.