### PR TITLE
fixed ExApp with one scope(llm2 for example) installation error

### DIFF
--- a/lib/Service/ExAppService.php
+++ b/lib/Service/ExAppService.php
@@ -274,7 +274,11 @@ class ExAppService {
 			}
 			$appInfo = json_decode(json_encode((array)$xmlAppInfo), true);
 			if (isset($appInfo['external-app']['scopes']['value'])) {
-				$appInfo['external-app']['scopes'] = $appInfo['external-app']['scopes']['value'];
+				if (is_array($appInfo['external-app']['scopes']['value'])) {
+					$appInfo['external-app']['scopes'] = $appInfo['external-app']['scopes']['value'];
+				} else {
+					$appInfo['external-app']['scopes'] = [$appInfo['external-app']['scopes']['value']];
+				}
 			}
 			if ($extractedDir) {
 				if (file_exists($extractedDir . '/l10n')) {
@@ -282,10 +286,6 @@ class ExAppService {
 				} else {
 					$this->logger->info(sprintf('Application %s does not support translations', $appId));
 				}
-			}
-			# TO-DO: remove this in AppAPI 2.3.0
-			if (isset($appInfo['external-app']['scopes']['required']['value'])) {
-				$appInfo['external-app']['scopes'] = $appInfo['external-app']['scopes']['required']['value'];
 			}
 		}
 		return $appInfo;


### PR DESCRIPTION
In our current code, `$appInfo['external-app']['scopes']['value']` is sometimes an array and sometimes not, depending on the data.

To ensure that `$appInfo['external-app']['scopes']` is always an array, even if it's just one value, we use the is_array() function to check the type and then adjust accordingly.

