### PR TITLE
fix incorrect init_timeout setting key

### DIFF
--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -94,7 +94,7 @@ export default {
 		onInput() {
 			delay(() => {
 				this.saveOptions({
-					ex_app_init_timeout: this.state.init_timeout,
+					init_timeout: this.state.init_timeout,
 					container_restart_policy: this.state.container_restart_policy,
 				})
 			}, 2000)()


### PR DESCRIPTION
In the UI not proper key was used to set a config key.

Related to: #287