### PR TITLE
correct the logs availability UI state

### DIFF
--- a/src/adminSettings.js
+++ b/src/adminSettings.js
@@ -2,6 +2,9 @@ import Vue from 'vue'
 import './bootstrap.js'
 import AdminSettings from './components/AdminSettings.vue'
 import { generateFilePath } from '@nextcloud/router'
+import { Tooltip } from '@nextcloud/vue'
+
+Vue.directive('tooltip', Tooltip)
 
 // eslint-disable-next-line
 __webpack_public_path__ = generateFilePath(appName, '', 'js/')

--- a/src/components/DaemonConfig/DaemonTestDeploy.vue
+++ b/src/components/DaemonConfig/DaemonTestDeploy.vue
@@ -55,6 +55,18 @@
 					{{ t('app_api', 'Download ExApp logs') }}
 				</NcButton>
 				<NcButton
+					v-if="!testRunning && hasTestDeployResults"
+					v-tooltip="{ content: t('app_api', 'Remove test ExApp'), placement: 'top' }"
+					:disabled="stoppingTest"
+					type="tertiary"
+					style="margin-right: 10px;"
+					@click="removeTestExApp">
+					<template #icon>
+						<TrashCan v-if="!stoppingTest" :size="20" />
+						<NcLoadingIcon v-else :size="20" />
+					</template>
+				</NcButton>
+				<NcButton
 					v-if="!testRunning"
 					:disabled="startingTest"
 					type="primary"
@@ -77,6 +89,9 @@
 					{{ t('app_api', 'Stop Deploy test') }}
 				</NcButton>
 			</div>
+			<p v-if="testRunning" class="warning-text">
+				{{ t('app_api', 'ExApp is unregistered and container is removed on "Stop deploy test"') }}
+			</p>
 		</div>
 	</NcModal>
 </template>
@@ -95,6 +110,7 @@ import Check from 'vue-material-design-icons/Check.vue'
 import StopIcon from 'vue-material-design-icons/Stop.vue'
 import OpenInNew from 'vue-material-design-icons/OpenInNew.vue'
 import Download from 'vue-material-design-icons/Download.vue'
+import TrashCan from 'vue-material-design-icons/TrashCan.vue'
 
 export default {
 	name: 'DaemonTestDeploy',
@@ -107,6 +123,7 @@ export default {
 		StopIcon,
 		OpenInNew,
 		Download,
+		TrashCan,
 	},
 	props: {
 		show: {
@@ -214,6 +231,9 @@ export default {
 			}
 			return null
 		},
+		hasTestDeployResults() {
+			return Object.values(this.statusChecks).some(statusCheck => statusCheck.passed || statusCheck.error)
+		},
 	},
 	beforeMount() {
 		this.fetchTestDeployStatus()
@@ -225,8 +245,7 @@ export default {
 		closeModal() {
 			this.$emit('update:show', false)
 		},
-		startDeployTest() {
-			this.startingTest = true
+		_cleanupStatusChecks() {
 			Object.values(this.statusChecks).forEach(statusCheck => {
 				statusCheck.loading = false
 				statusCheck.passed = false
@@ -239,6 +258,10 @@ export default {
 					statusCheck.heartbeat_count = null
 				}
 			})
+		},
+		startDeployTest() {
+			this.startingTest = true
+			this._cleanupStatusChecks()
 			this._startDeployTest().then((res) => {
 				this.testRunning = true
 				if (this._detectCurrentStep(res.data.status) === 'register') {
@@ -271,6 +294,11 @@ export default {
 			this.polling = setInterval(() => {
 				this.fetchTestDeployStatus()
 			}, 1000)
+		},
+		removeTestExApp() {
+			this._stopDeployTest().then(() => {
+				this._cleanupStatusChecks()
+			})
 		},
 		stopDeployTest() {
 			this._stopDeployTest().then(() => {
@@ -439,6 +467,13 @@ export default {
 
 	.error {
 		color: var(--color-error-text);
+	}
+
+	.warning-text {
+		display: flex;
+		justify-content: flex-end;
+		margin-top: 10px;
+		color: var(--color-warning-text);
 	}
 }
 </style>

--- a/src/components/DaemonConfig/DaemonTestDeploy.vue
+++ b/src/components/DaemonConfig/DaemonTestDeploy.vue
@@ -43,6 +43,8 @@
 			</div>
 			<div class="actions">
 				<NcButton
+					v-tooltip="{ content: downloadLogsTooltip, placement: 'top' }"
+					:disabled="!canDownloadLogs"
 					type="tertiary"
 					:href="getDownloadLogsUrl()"
 					target="_blank"
@@ -128,6 +130,7 @@ export default {
 			stoppingTest: false,
 			testRunning: false,
 			polling: null,
+			canDownloadLogs: false,
 			statusChecks: {
 				register: {
 					id: 'register',
@@ -204,6 +207,12 @@ export default {
 		},
 		initHeadingProgress() {
 			return `${this.statusChecks.init.title} (${this.statusChecks.init.progress}%)`
+		},
+		downloadLogsTooltip() {
+			if (!this.canDownloadLogs) {
+				return t('app_api', 'Only if ExApp container is preset')
+			}
+			return null
 		},
 	},
 	beforeMount() {
@@ -320,12 +329,15 @@ export default {
 					break
 				case 'container_started':
 					statusCheck.passed = status.deploy >= 98
+					this.canDownloadLogs = true // at status.deploy = 97  container is already created
 					break
 				case 'heartbeat':
 					statusCheck.passed = status.deploy === 100
+					this.canDownloadLogs = true
 					break
 				case 'init':
 					statusCheck.passed = status.init === 100
+					this.canDownloadLogs = true
 					break
 				case 'enabled':
 					statusCheck.passed = status.init === 100 && status.deploy === 100 && status.action === '' && status.error === ''
@@ -401,6 +413,9 @@ export default {
 			this.polling = null
 		},
 		getDownloadLogsUrl() {
+			if (!this.canDownloadLogs) {
+				return null
+			}
 			return generateUrl('/apps/app_api/apps/logs/test-deploy')
 		},
 	},


### PR DESCRIPTION
Set "Download ExApp logs" button availability depending on the "Test Deploy" step. Logs can be obtained only starting from "container_started" step, when the ExApp docker container is created.

Resolves: #286