### PR TITLE
UIProxy: fixed incorrect the Domain of `cookie`

### DIFF
--- a/lib/Controller/ExAppProxyController.php
+++ b/lib/Controller/ExAppProxyController.php
@@ -83,7 +83,7 @@ class ExAppProxyController extends Controller {
 
 		$response = $this->service->aeRequestToExApp2(
 			$exApp, '/' . $other, $this->userId, 'GET', queryParams: $_GET, options: [
-				RequestOptions::COOKIES => $this->buildProxyCookiesJar($_COOKIE, $exApp->getHost()),
+				RequestOptions::COOKIES => $this->buildProxyCookiesJar($_COOKIE, $this->service->getExAppDomain($exApp)),
 			],
 			request: $this->request,
 		);
@@ -102,7 +102,7 @@ class ExAppProxyController extends Controller {
 		}
 
 		$options = [
-			RequestOptions::COOKIES => $this->buildProxyCookiesJar($_COOKIE, $exApp->getHost()),
+			RequestOptions::COOKIES => $this->buildProxyCookiesJar($_COOKIE, $this->service->getExAppDomain($exApp)),
 		];
 		if (str_starts_with($this->request->getHeader('Content-Type'), 'multipart/form-data') || count($_FILES) > 0) {
 			$multipart = $this->buildMultipartFormData($this->prepareBodyParams($this->request->getParams()), $_FILES);
@@ -130,7 +130,7 @@ class ExAppProxyController extends Controller {
 		}
 
 		$options = [
-			RequestOptions::COOKIES => $this->buildProxyCookiesJar($_COOKIE, $exApp->getHost()),
+			RequestOptions::COOKIES => $this->buildProxyCookiesJar($_COOKIE, $this->service->getExAppDomain($exApp)),
 		];
 		if (str_starts_with($this->request->getHeader('Content-Type'), 'multipart/form-data') || count($_FILES) > 0) {
 			$multipart = $this->buildMultipartFormData($this->prepareBodyParams($this->request->getParams()), $_FILES);
@@ -161,7 +161,7 @@ class ExAppProxyController extends Controller {
 		$response = $this->service->aeRequestToExApp2(
 			$exApp, '/' . $other, $this->userId, 'DELETE', queryParams: $_GET, bodyParams: $bodyParams,
 			options: [
-				RequestOptions::COOKIES => $this->buildProxyCookiesJar($_COOKIE, $exApp->getHost()),
+				RequestOptions::COOKIES => $this->buildProxyCookiesJar($_COOKIE, $this->service->getExAppDomain($exApp)),
 			],
 			request: $this->request,
 		);

--- a/lib/Service/AppAPIService.php
+++ b/lib/Service/AppAPIService.php
@@ -706,6 +706,13 @@ class AppAPIService {
 		}
 	}
 
+	public function getExAppDomain(ExApp $exApp): string {
+		$auth = [];
+		$appFullUrl = $this->getExAppUrl($exApp, 0, $auth);
+		$urlComponents = parse_url($appFullUrl);
+		return $urlComponents['host'] ?? '';
+	}
+
 	/**
 	 * Enable ExApp. Sends request to ExApp to update enabled state.
 	 * If request fails, ExApp will be disabled.


### PR DESCRIPTION
Currently cookies always rejected when ExApp is installed in DSP with `HTTPS` - this is now fixed.