### PR TITLE
fix(ui): add warning for http nextcloud url in https daemon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2.7.0 - 2024-07-0x]
+
+### Fixed
+
+- Nextcloud URL state warning in the Register daemon form for HTTPS configuration. #312
+
 ## [2.6.0 - 2024-05-10]
 
 ### Added

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -43,7 +43,7 @@ to join us in shaping a more versatile, stable, and secure app landscape.
 *Your insights, suggestions, and contributions are invaluable to us.*
 
 	]]></description>
-	<version>2.6.0</version>
+	<version>2.7.0</version>
 	<licence>agpl</licence>
 	<author mail="andrey18106x@gmail.com" homepage="https://github.com/andrey18106">Andrey Borysenko</author>
 	<author mail="bigcat88@icloud.com" homepage="https://github.com/bigcat88">Alexander Piskun</author>

--- a/src/components/DaemonConfig/RegisterDaemonConfigModal.vue
+++ b/src/components/DaemonConfig/RegisterDaemonConfigModal.vue
@@ -62,7 +62,7 @@
 							:value.sync="nextcloud_url"
 							style="max-width: 70%;"
 							:placeholder="t('app_api', 'Nextcloud URL')"
-							:aria-label="t('app_api', 'Nextcloud URL')"/>
+							:aria-label="t('app_api', 'Nextcloud URL')" />
 					</div>
 					<div class="row">
 						<NcCheckboxRadioSwitch

--- a/src/components/DaemonConfig/RegisterDaemonConfigModal.vue
+++ b/src/components/DaemonConfig/RegisterDaemonConfigModal.vue
@@ -57,9 +57,12 @@
 						<label for="nextcloud-url">{{ t('app_api', 'Nextcloud URL') }}</label>
 						<NcInputField
 							id="nextcloud-url"
+							:helper-text="isNextcloudUrlSafeHelpText"
+							:input-class="!isNextcloudUrlSafe ? 'text-warning' : ''"
 							:value.sync="nextcloud_url"
+							style="max-width: 70%;"
 							:placeholder="t('app_api', 'Nextcloud URL')"
-							:aria-label="t('app_api', 'Nextcloud URL')" />
+							:aria-label="t('app_api', 'Nextcloud URL')"/>
 					</div>
 					<div class="row">
 						<NcCheckboxRadioSwitch
@@ -356,6 +359,15 @@ export default {
 		isAdditionalOptionValid() {
 			return this.additionalOption.key.trim() !== '' && this.additionalOption.value.trim() !== ''
 		},
+		isNextcloudUrlSafe() {
+			if (this.httpsEnabled) {
+				return this.nextcloud_url.startsWith('https://')
+			}
+			return this.nextcloud_url.startsWith('http://') || this.nextcloud_url.startsWith('https://')
+		},
+		isNextcloudUrlSafeHelpText() {
+			return this.isNextcloudUrlSafe ? '' : t('app_api', 'For HTTPS daemon, Nextcloud URL should be HTTPS')
+		},
 	},
 	watch: {
 		configurationTab(newConfigurationTab) {
@@ -539,6 +551,15 @@ export default {
 
 	.additional-option {
 		display: flex;
+	}
+}
+</style>
+
+<style lang="scss">
+.register-daemon-config-body {
+	.input-field__input.text-warning {
+		border-color: var(--color-warning-text) !important;
+		color: var(--color-warning-text) !important;
 	}
 }
 </style>


### PR DESCRIPTION
Resolves: #298 

<img width="576" alt="Screenshot 2024-07-01 at 4 24 33 PM" src="https://github.com/cloud-py-api/app_api/assets/29692256/c2fb8113-15dd-42c8-97cf-9e0451fa015f">
