### PR TITLE
fix(ui): correct update of image_pull and init progress in test deploy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Allow ExApps management disable and remove actions if default Deploy daemon is not accessible. #314
 - Fixed Deploy daemon avilability check using ping timeout set to 3s. #314
+- Fix Test Deploy `image_pull` and `init` steps status update. #315
 
 ## [2.7.0 - 2024-07-01]
 

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -43,7 +43,7 @@ to join us in shaping a more versatile, stable, and secure app landscape.
 *Your insights, suggestions, and contributions are invaluable to us.*
 
 	]]></description>
-	<version>2.7.0</version>
+	<version>2.7.1</version>
 	<licence>agpl</licence>
 	<author mail="andrey18106x@gmail.com" homepage="https://github.com/andrey18106">Andrey Borysenko</author>
 	<author mail="bigcat88@icloud.com" homepage="https://github.com/bigcat88">Alexander Piskun</author>

--- a/src/components/DaemonConfig/DaemonTestDeploy.vue
+++ b/src/components/DaemonConfig/DaemonTestDeploy.vue
@@ -357,14 +357,22 @@ export default {
 					break
 				case 'heartbeat':
 					statusCheck.passed = status.deploy === 100
+					// update later 'image_pull' progress as well
+					this.statusChecks.image_pull.progress = status.deploy
 					this.canDownloadLogs = true
 					break
 				case 'init':
 					statusCheck.passed = status.init === 100
+					// update later 'image_pull' and 'init' progress as well
+					this.statusChecks.image_pull.progress = status.deploy
+					this.statusChecks.init.progress = status.init
 					this.canDownloadLogs = true
 					break
 				case 'enabled':
 					statusCheck.passed = status.init === 100 && status.deploy === 100 && status.action === '' && status.error === ''
+					// update later 'image_pull' and 'init' progress as well
+					this.statusChecks.image_pull.progress = status.deploy
+					this.statusChecks.init.progress = status.init
 					if (statusCheck.passed) {
 						showSuccess(t('app_api', 'Deploy test passed successfully!'))
 						this.clearTestRunning()


### PR DESCRIPTION
Resolves: #299

Update `image_pull` and `init` progress in further status checks as well in test deploy modal.