### PR TITLE
AppAPIProxy: fixed `PUT` requests processing with content

### DIFF
--- a/tests/psalm-baseline.xml
+++ b/tests/psalm-baseline.xml
@@ -18,7 +18,6 @@
       <code><![CDATA[RequestOptions]]></code>
       <code><![CDATA[RequestOptions]]></code>
       <code><![CDATA[RequestOptions]]></code>
-      <code><![CDATA[RequestOptions]]></code>
       <code><![CDATA[SetCookie]]></code>
     </UndefinedClass>
   </file>


### PR DESCRIPTION
Treat `PUT` with the same logic as `DELETE`

`$_POST` and `$_FILES` are always empty as PHP automatically does not parse data during `PUT`

Just send raw request which we received to ExApp.

