### PR TITLE
fix: preserve original Authentication to be swapped later in HaProxy

### DIFF
--- a/lib/DeployActions/DockerActions.php
+++ b/lib/DeployActions/DockerActions.php
@@ -527,7 +527,8 @@ class DockerActions implements IDeployActions {
 		} else {
 			$exAppHost = $appId;
 		}
-		if (isset($deployConfig['haproxy_password']) && $deployConfig['haproxy_password'] !== '') {
+		if ($protocol == 'https' && isset($deployConfig['haproxy_password']) && $deployConfig['haproxy_password'] !== '') {
+			// we only set haproxy auth for remote installations, when all requests come through HaProxy.
 			$auth = [self::APP_API_HAPROXY_USER, $deployConfig['haproxy_password']];
 		}
 		return sprintf('%s://%s:%s', $protocol, $exAppHost, $port);

--- a/lib/Service/AppAPIService.php
+++ b/lib/Service/AppAPIService.php
@@ -172,7 +172,7 @@ class AppAPIService {
 		$options['http_errors'] = false; // do not throw exceptions on 4xx and 5xx responses
 		if (!empty($auth)) {
 			$options['auth'] = $auth;
-			$options['headers'] = $this->swapAuthenticationHeader($options['headers']);
+			$options['headers'] = $this->swapAuthorizationHeader($options['headers']);
 		}
 		if (!isset($options['timeout'])) {
 			$options['timeout'] = 3;
@@ -222,7 +222,7 @@ class AppAPIService {
 		$options['http_errors'] = false; // do not throw exceptions on 4xx and 5xx responses
 		if (!empty($auth)) {
 			$options['auth'] = $auth;
-			$options['headers'] = $this->swapAuthenticationHeader($options['headers']);
+			$options['headers'] = $this->swapAuthorizationHeader($options['headers']);
 		}
 		if (!isset($options['timeout'])) {
 			$options['timeout'] = 3;
@@ -241,14 +241,18 @@ class AppAPIService {
 
 	/**
 	 * This is required for AppAPI Docker Socket Proxy, as the Basic Auth is already in use by HaProxy,
-	 * and the incoming request's Authentication is replaced with X-Original-Authentication header
+	 * and the incoming request's Authorization is replaced with X-Original-Authorization header
 	 * after HaProxy authenticated.
 	 *
 	 * @since AppAPI 3.0.0
 	 */
-	private function swapAuthenticationHeader(array $headers): array {
-		if (isset($headers['Authorization'])) {
-			$headers['X-Original-Authentication'] = $headers['Authorization'];
+
+	private function swapAuthorizationHeader(array $headers): array {
+		foreach ($headers as $key => $value) {
+			if (strtoupper($key) === 'AUTHORIZATION') {
+				$headers['X-Original-Authorization'] = $value;
+				break;
+			}
 		}
 		return $headers;
 	}

--- a/lib/Service/AppAPIService.php
+++ b/lib/Service/AppAPIService.php
@@ -172,6 +172,7 @@ class AppAPIService {
 		$options['http_errors'] = false; // do not throw exceptions on 4xx and 5xx responses
 		if (!empty($auth)) {
 			$options['auth'] = $auth;
+			$options['headers'] = $this->swapAuthenticationHeader($options['headers']);
 		}
 		if (!isset($options['timeout'])) {
 			$options['timeout'] = 3;
@@ -221,6 +222,7 @@ class AppAPIService {
 		$options['http_errors'] = false; // do not throw exceptions on 4xx and 5xx responses
 		if (!empty($auth)) {
 			$options['auth'] = $auth;
+			$options['headers'] = $this->swapAuthenticationHeader($options['headers']);
 		}
 		if (!isset($options['timeout'])) {
 			$options['timeout'] = 3;
@@ -235,6 +237,20 @@ class AppAPIService {
 			}
 		}
 		return ['url' => $url, 'options' => $options];
+	}
+
+	/**
+	 * This is required for AppAPI Docker Socket Proxy, as the Basic Auth is already in use by HaProxy,
+	 * and the incoming request's Authentication is replaced with X-Original-Authentication header
+	 * after HaProxy authenticated.
+	 *
+	 * @since AppAPI 3.0.0
+	 */
+	private function swapAuthenticationHeader(array $headers): array {
+		if (isset($headers['Authorization'])) {
+			$headers['X-Original-Authentication'] = $headers['Authorization'];
+		}
+		return $headers;
 	}
 
 	private function getUriEncodedParams(array $params): string {


### PR DESCRIPTION
Ref: https://github.com/cloud-py-api/docker-socket-proxy/pull/33