### PR TITLE
always set COMPUTE_DEVICE in UpperCase

### DIFF
--- a/lib/DeployActions/DockerActions.php
+++ b/lib/DeployActions/DockerActions.php
@@ -493,8 +493,8 @@ class DockerActions implements IDeployActions {
 			sprintf('NEXTCLOUD_URL=%s', $deployConfig['nextcloud_url'] ?? str_replace('https', 'http', $this->urlGenerator->getAbsoluteURL(''))),
 		];
 
-		// Always set COMPUTE_DEVICE=cpu|cuda|rocm
-		$autoEnvs[] = sprintf('COMPUTE_DEVICE=%s', $deployConfig['computeDevice']['id']);
+		// Always set COMPUTE_DEVICE=CPU|CUDA|ROCM
+		$autoEnvs[] = sprintf('COMPUTE_DEVICE=%s', strtoupper($deployConfig['computeDevice']['id']));
 		// Add required GPU runtime envs if daemon configured to use GPU
 		if (isset($deployConfig['computeDevice'])) {
 			if ($deployConfig['computeDevice']['id'] === 'cuda') {


### PR DESCRIPTION
For convenience, we should have done this in UpperCase initially.

I will fix it in `nc_py_api` so that it is always converted before comparison, but this should also be unified on the AppAPI side