### PR TITLE
fix: disable caching if APCu detected

### DIFF
--- a/lib/Service/ExAppService.php
+++ b/lib/Service/ExAppService.php
@@ -24,6 +24,7 @@ use OCP\AppFramework\Db\MultipleObjectsReturnedException;
 use OCP\DB\Exception;
 use OCP\ICache;
 use OCP\ICacheFactory;
+use OCP\IConfig;
 use OCP\IUser;
 use OCP\IUserManager;
 use Psr\Log\LoggerInterface;
@@ -53,9 +54,17 @@ class ExAppService {
 		private readonly SettingsService            $settingsService,
 		private readonly ExAppEventsListenerService $eventsListenerService,
 		private readonly ExAppOccService            $occService,
+		private readonly IConfig                    $config,
 	) {
 		if ($cacheFactory->isAvailable()) {
-			$this->cache = $cacheFactory->createDistributed(Application::APP_ID . '/service');
+			$distributedCacheClass = ltrim($config->getSystemValueString('memcache.distributed', ''), '\\');
+			$localCacheClass = ltrim($config->getSystemValueString('memcache.local', ''), '\\');
+			if (
+				($distributedCacheClass === '' && ($localCacheClass !== \OC\Memcache\APCu::class)) &&
+				($distributedCacheClass !== \OC\Memcache\APCu::class)
+			) {
+				$this->cache = $cacheFactory->createDistributed(Application::APP_ID . '/service');
+			}
 		}
 	}
 

--- a/tests/psalm-baseline.xml
+++ b/tests/psalm-baseline.xml
@@ -112,4 +112,10 @@
       <code><![CDATA[IEventListener]]></code>
     </MissingTemplateParam>
   </file>
+  <file src="lib/Service/ExAppService.php">
+    <UndefinedClass>
+      <code><![CDATA[\OC\Memcache\APCu]]></code>
+      <code><![CDATA[\OC\Memcache\APCu]]></code>
+    </UndefinedClass>
+  </file>
 </files>


### PR DESCRIPTION
We do not disable caches in other places as in CLI only `/ex_apps` cache is used.

Linked issue: https://github.com/cloud-py-api/app_api/issues/291