### PR TITLE
feat(ci): add test with APCu local cache enabled

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -230,7 +230,6 @@ jobs:
           ./occ maintenance:install --verbose --database=mysql --database-name=nextcloud \
             --database-host=127.0.0.1 --database-port=$DB_PORT --database-user=root --database-pass=rootpassword \
             --admin-user admin --admin-pass admin
-          ./occ app:enable --force ${{ env.APP_NAME }}
           ./occ app:enable notifications
           ./occ app:enable --force ${{ env.APP_NAME }}
 
@@ -267,6 +266,120 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: mysql_nc_py_api_stable28_8.1_nextcloud.log
+          path: data/nextcloud.log
+          if-no-files-found: warn
+
+  nc-py-api-mysql-apcu:
+    runs-on: ubuntu-22.04
+    name: APCu • NC_Py_API • stable28 • 8.1 • MySQL
+
+    services:
+      mysql:
+        image: ghcr.io/nextcloud/continuous-integration-mysql-8.1:latest
+        ports:
+          - 4444:3306/tcp
+        env:
+          MYSQL_ROOT_PASSWORD: rootpassword
+        options: --health-cmd="mysqladmin ping" --health-interval 5s --health-timeout 2s --health-retries 5
+
+    steps:
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+
+      - name: Set app env
+        run: echo "APP_NAME=${GITHUB_REPOSITORY##*/}" >> $GITHUB_ENV
+
+      - name: Checkout server
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+        with:
+          submodules: true
+          repository: nextcloud/server
+          ref: stable28
+
+      - name: Checkout Notifications
+        uses: actions/checkout@v3
+        with:
+          repository: nextcloud/notifications
+          ref: stable28
+          path: apps/notifications
+
+      - name: Checkout AppAPI
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+        with:
+          path: apps/${{ env.APP_NAME }}
+
+      - name: Set up php 8.1
+        uses: shivammathur/setup-php@4bd44f22a98a19e0950cbad5f31095157cc9621b # v2
+        with:
+          php-version: '8.1'
+          extensions: bz2, ctype, curl, dom, fileinfo, gd, iconv, intl, json, libxml, mbstring, openssl, pcntl, posix, session, simplexml, xmlreader, xmlwriter, zip, zlib, mysql, pdo_mysql, apcu
+          coverage: none
+          ini-file: development
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable ONLY_FULL_GROUP_BY MySQL option
+        run: |
+          echo "SET GLOBAL sql_mode=(SELECT CONCAT(@@sql_mode,',ONLY_FULL_GROUP_BY'));" | mysql -h 127.0.0.1 -P 4444 -u root -prootpassword
+          echo "SELECT @@sql_mode;" | mysql -h 127.0.0.1 -P 4444 -u root -prootpassword
+
+      - name: Check composer file existence
+        id: check_composer
+        uses: andstor/file-existence-action@20b4d2e596410855db8f9ca21e96fbe18e12930b # v2
+        with:
+          files: apps/${{ env.APP_NAME }}/composer.json
+
+      - name: Set up dependencies
+        if: steps.check_composer.outputs.files_exists == 'true'
+        working-directory: apps/${{ env.APP_NAME }}
+        run: composer i
+
+      - name: Set up Nextcloud
+        env:
+          DB_PORT: 4444
+        run: |
+          mkdir data
+          ./occ maintenance:install --verbose --database=mysql --database-name=nextcloud \
+            --database-host=127.0.0.1 --database-port=$DB_PORT --database-user=root --database-pass=rootpassword \
+            --admin-user admin --admin-pass admin
+          ./occ config:system:set memcache.local --value "\\OC\\Memcache\\APCu" --type string
+          ./occ app:enable notifications
+          ./occ app:enable --force ${{ env.APP_NAME }}
+
+      - name: Run Nextcloud
+        run: PHP_CLI_SERVER_WORKERS=2 php -S 127.0.0.1:8080 &
+
+      - name: Checkout NcPyApi
+        uses: actions/checkout@v3
+        with:
+          path: nc_py_api
+          repository: cloud-py-api/nc_py_api
+
+      - name: Install NcPyApi
+        working-directory: nc_py_api
+        run: python3 -m pip -v install ".[dev]"
+
+      - name: Register NcPyApi
+        run: |
+          cd nc_py_api
+          python3 tests/_install.py &
+          echo $! > /tmp/_install.pid
+          python3 tests/_install_wait.py http://127.0.0.1:$APP_PORT/heartbeat "\"status\":\"ok\"" 15 0.5
+          cd ..
+          sh nc_py_api/scripts/ci_register.sh "$APP_ID" "$APP_VERSION" "$APP_SECRET" "localhost" "$APP_PORT"
+          kill -15 $(cat /tmp/_install.pid)
+          timeout 3m tail --pid=$(cat /tmp/_install.pid) -f /dev/null
+
+      - name: Run NC_Py_API tests
+        working-directory: nc_py_api
+        run: python3 -m pytest
+
+      - name: Upload NC logs
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: apcu_mysql_nc_py_api_stable28_8.1_nextcloud.log
           path: data/nextcloud.log
           if-no-files-found: warn
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -271,7 +271,7 @@ jobs:
 
   nc-py-api-mysql-apcu:
     runs-on: ubuntu-22.04
-    name: APCu • NC_Py_API • stable28 • 8.1 • MySQL
+    name: APCu • NC_Py_API • stable29 • 8.1 • MySQL
 
     services:
       mysql:
@@ -295,7 +295,7 @@ jobs:
         with:
           submodules: true
           repository: nextcloud/server
-          ref: stable28
+          ref: stable29
 
       - name: Checkout Notifications
         uses: actions/checkout@v3
@@ -316,6 +316,8 @@ jobs:
           extensions: bz2, ctype, curl, dom, fileinfo, gd, iconv, intl, json, libxml, mbstring, openssl, pcntl, posix, session, simplexml, xmlreader, xmlwriter, zip, zlib, mysql, pdo_mysql, apcu
           coverage: none
           ini-file: development
+          ini-values:
+            apc.enabled=on, apc.enable_cli=on
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -379,7 +381,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: apcu_mysql_nc_py_api_stable28_8.1_nextcloud.log
+          name: apcu_mysql_nc_py_api_stable29_8.1_nextcloud.log
           path: data/nextcloud.log
           if-no-files-found: warn
 


### PR DESCRIPTION
Add CI test with APCu enabled (ref: https://github.com/cloud-py-api/app_api/pull/348).

APCu test must fail on ExApp register step, and be resolved in linked PR.