### PR TITLE
fix: Proxy: do not trust input - always set own value for 'X-Origin-IP'

### DIFF
--- a/lib/Controller/ExAppProxyController.php
+++ b/lib/Controller/ExAppProxyController.php
@@ -255,17 +255,16 @@ class ExAppProxyController extends Controller {
 				break;
 			}
 		}
-		if (empty($headersToExclude)) {
-			return $headers;
+		if (!in_array('x-origin-ip', $headersToExclude)) {
+			$headersToExclude[] = 'x-origin-ip';
 		}
+		$headersToExclude[] = 'authorization-app-api';
 		foreach ($headers as $key => $value) {
 			if (in_array(strtolower($key), $headersToExclude)) {
 				unset($headers[$key]);
 			}
 		}
-		if (!isset($headers['X-Origin-IP'])) {
-			$headers['X-Origin-IP'] = $this->request->getRemoteAddress();
-		}
+		$headers['X-Origin-IP'] = $this->request->getRemoteAddress();
 		return $headers;
 	}
 }


### PR DESCRIPTION
An external packet received by the proxy can have any value in 'X-Origin-IP' - we can't trust it, it's best to set it on our own