### PR TITLE
Proxy: do not set timeout for requests to ExApp

### DIFF
--- a/lib/Controller/ExAppProxyController.php
+++ b/lib/Controller/ExAppProxyController.php
@@ -91,6 +91,7 @@ class ExAppProxyController extends Controller {
 			$exApp, '/' . $other, $this->userId, 'GET', queryParams: $_GET, options: [
 				RequestOptions::COOKIES => $this->buildProxyCookiesJar($_COOKIE, $this->service->getExAppDomain($exApp)),
 				RequestOptions::HEADERS => $this->buildHeadersWithExclude($exApp, $other, getallheaders()),
+				RequestOptions::TIMEOUT => 0,
 			],
 			request: $this->request,
 		);
@@ -112,6 +113,7 @@ class ExAppProxyController extends Controller {
 		$options = [
 			RequestOptions::COOKIES => $this->buildProxyCookiesJar($_COOKIE, $this->service->getExAppDomain($exApp)),
 			RequestOptions::HEADERS => $this->buildHeadersWithExclude($exApp, $other, getallheaders()),
+			RequestOptions::TIMEOUT => 0,
 		];
 		if (str_starts_with($this->request->getHeader('Content-Type'), 'multipart/form-data') || count($_FILES) > 0) {
 			unset($options['headers']['Content-Type']);
@@ -149,6 +151,7 @@ class ExAppProxyController extends Controller {
 			RequestOptions::COOKIES => $this->buildProxyCookiesJar($_COOKIE, $this->service->getExAppDomain($exApp)),
 			RequestOptions::BODY => $stream,
 			RequestOptions::HEADERS => $this->buildHeadersWithExclude($exApp, $other, getallheaders()),
+			RequestOptions::TIMEOUT => 0,
 		];
 		$response = $this->service->requestToExApp2(
 			$exApp, '/' . $other, $this->userId, 'PUT',
@@ -175,6 +178,7 @@ class ExAppProxyController extends Controller {
 			RequestOptions::COOKIES => $this->buildProxyCookiesJar($_COOKIE, $this->service->getExAppDomain($exApp)),
 			RequestOptions::BODY => $stream,
 			RequestOptions::HEADERS => $this->buildHeadersWithExclude($exApp, $other, getallheaders()),
+			RequestOptions::TIMEOUT => 0,
 		];
 		$response = $this->service->requestToExApp2(
 			$exApp, '/' . $other, $this->userId, 'DELETE',

--- a/tests/psalm-baseline.xml
+++ b/tests/psalm-baseline.xml
@@ -26,6 +26,10 @@
       <code><![CDATA[RequestOptions]]></code>
       <code><![CDATA[RequestOptions]]></code>
       <code><![CDATA[RequestOptions]]></code>
+      <code><![CDATA[RequestOptions]]></code>
+      <code><![CDATA[RequestOptions]]></code>
+      <code><![CDATA[RequestOptions]]></code>
+      <code><![CDATA[RequestOptions]]></code>
       <code><![CDATA[SetCookie]]></code>
     </UndefinedClass>
   </file>


### PR DESCRIPTION
We forgot to change this in this PR: https://github.com/cloud-py-api/app_api/pull/277

For Proxy requests there should be no timeout, cause they are coming from user or external services and not from Nextcloud

Even if they will take a long time, Nextcloud instance will be not slow down