### PR TITLE
ability to enable bruteforce protection for ExApp routes

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -43,7 +43,7 @@ to join us in shaping a more versatile, stable, and secure app landscape.
 *Your insights, suggestions, and contributions are invaluable to us.*
 
 	]]></description>
-	<version>3.1.0</version>
+	<version>3.1.1</version>
 	<licence>agpl</licence>
 	<author mail="andrey18106x@gmail.com" homepage="https://github.com/andrey18106">Andrey Borysenko</author>
 	<author mail="bigcat88@icloud.com" homepage="https://github.com/bigcat88">Alexander Piskun</author>

--- a/docs/tech_details/api/routes.rst
+++ b/docs/tech_details/api/routes.rst
@@ -28,6 +28,7 @@ Example
 			<verb>GET,POST,PUT,DELETE</verb>
 			<access_level>USER</access_level>
 			<headers_to_exclude>[]</headers_to_exclude>
+			<bruteforce_protection>[401, 500]</bruteforce_protection>
 		</route>
 	</routes>
 
@@ -37,6 +38,7 @@ where the fields are:
 - ``verb``: the HTTP verb that the route will accept, can be a comma separated list of verbs
 - ``access_level``: the name of the access level required to access the route, PUBLIC - public access without auth, USER - Nextcloud user auth required, ADMIN - admin user required
 - ``headers_to_exclude``: a json encoded string of an array of strings, the headers that the ExApp wants to be excluded from the request to it
+- ``bruteforce_protection``: a json encoded string of an array of numbers, the HTTP status codes that must trigger the bruteforce protection
 
 
 Unregister

--- a/lib/Db/ExAppMapper.php
+++ b/lib/Db/ExAppMapper.php
@@ -37,6 +37,7 @@ class ExAppMapper extends QBMapper {
 			'r.verb',
 			'r.access_level',
 			'r.headers_to_exclude',
+			'r.bruteforce_protection',
 		)
 			->from($this->tableName, 'a')
 			->leftJoin('a', 'ex_apps_daemons', 'd', $qb->expr()->eq('a.daemon_config_name', 'd.name'))
@@ -68,6 +69,7 @@ class ExAppMapper extends QBMapper {
 			'r.verb',
 			'r.access_level',
 			'r.headers_to_exclude',
+			'r.bruteforce_protection',
 		)
 			->from($this->tableName, 'a')
 			->leftJoin('a', 'ex_apps_daemons', 'd', $qb->expr()->eq('a.daemon_config_name', 'd.name'))
@@ -125,6 +127,7 @@ class ExAppMapper extends QBMapper {
 					'verb' => $row['verb'],
 					'access_level' => $row['access_level'],
 					'headers_to_exclude' => $row['headers_to_exclude'],
+					'bruteforce_protection' => $row['bruteforce_protection'],
 				];
 				$lastAppRoutes = $lastApp->getRoutes();
 				$lastAppRoutes[] = $route;
@@ -195,6 +198,9 @@ class ExAppMapper extends QBMapper {
 		$qb = $this->db->getQueryBuilder();
 		$count = 0;
 		foreach ($routes as $route) {
+			if (isset($route['bruteforce_protection']) && is_string($route['bruteforce_protection'])) {
+				$route['bruteforce_protection'] = json_decode($route['bruteforce_protection'], false);
+			}
 			$qb->insert('ex_apps_routes')
 				->values([
 					'appid' => $qb->createNamedParameter($exApp->getAppid()),
@@ -202,6 +208,11 @@ class ExAppMapper extends QBMapper {
 					'verb' => $qb->createNamedParameter($route['verb']),
 					'access_level' => $qb->createNamedParameter($route['access_level']),
 					'headers_to_exclude' => $qb->createNamedParameter(is_array($route['headers_to_exclude']) ? json_encode($route['headers_to_exclude']) : '[]'),
+					'bruteforce_protection' => $qb->createNamedParameter(
+						isset($route['bruteforce_protection']) && is_array($route['bruteforce_protection'])
+							? json_encode($route['bruteforce_protection'])
+							: '[]'
+					),
 				]);
 			$count += $qb->executeStatement();
 		}

--- a/lib/Migration/Version3100Date20240822080316.php
+++ b/lib/Migration/Version3100Date20240822080316.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\AppAPI\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+class Version3100Date20240822080316 extends SimpleMigrationStep {
+	/**
+	 * @param IOutput $output
+	 * @param Closure(): ISchemaWrapper $schemaClosure
+	 * @param array $options
+	 * @return null|ISchemaWrapper
+	 */
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		$table = $schema->getTable('ex_apps_routes');
+		if (!$table->hasColumn('bruteforce_protection')) {
+			$table->addColumn('bruteforce_protection', Types::STRING, [
+				'notnull' => false,
+				'length' => 512,
+			]);
+		}
+
+		return $schema;
+	}
+}


### PR DESCRIPTION
```xml
<route>
	<url>^api\/w\/nextcloud\/jobs\/.*</url>
	<verb>GET,POST,PUT,DELETE</verb>
	<access_level>PUBLIC</access_level>
	<headers_to_exclude>[]</headers_to_exclude>
	<bruteforce_protection>[401, 500]</bruteforce_protection>
</route>
```

Looks like this. ExApps should not implement its own protection, we should provide a way to enable basic protection from Nextcloud/AppAPI side.



