### PR TITLE
fix(cli): do not remove persistent storage by default in ExApp unregister command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - TaskProcessing: fixed bug when provider wasn't removed on unregister. #370
+- OCC: ExApp unregister command now doesn't remove volume by default. #381
 
 ### Removed
 

--- a/docs/ManagingExternalApplications.rst
+++ b/docs/ManagingExternalApplications.rst
@@ -45,7 +45,7 @@ Options
 Unregister
 ----------
 
-Command: ``app_api:app:unregister [--keep-data] [--force] [--silent] [--] <appid>``
+Command: ``app_api:app:unregister [--rm-data] [--force] [--silent] [--] <appid>``
 
 To remove an ExApp you can use the unregister command.
 There are additional options to keep the ExApp persistent storage (data volume).
@@ -58,7 +58,7 @@ Arguments
 Options
 *******
 
-    * ``--keep-data`` *[optional]* - keep ExApp persistent storage (data volume)
+    * ``--rm-data`` *[optional]* - remove ExApp persistent storage (data volume)
 	* ``--force`` *[optional]* - continue removal even if some error occurs.
 	* ``--silent`` *[optional]* - print a minimum of information, display only some errors, if any.
 

--- a/lib/Command/ExApp/Unregister.php
+++ b/lib/Command/ExApp/Unregister.php
@@ -42,19 +42,20 @@ class Unregister extends Command {
 			null,
 			InputOption::VALUE_NONE,
 			'Continue removal even if errors.');
-		$this->addOption('keep-data', null, InputOption::VALUE_NONE, 'Keep ExApp data (volume)');
+		$this->addOption('keep-data', null, InputOption::VALUE_NONE, 'Keep ExApp data (volume) [deprecated, data always kept].');
+		$this->addOption('rm-data', null, InputOption::VALUE_NONE, 'Remove ExApp data (persistent storage volume).');
 
 		$this->addUsage('test_app');
 		$this->addUsage('test_app --silent');
-		$this->addUsage('test_app --keep-data');
-		$this->addUsage('test_app --silent --force --keep-data');
+		$this->addUsage('test_app --rm-data');
+		$this->addUsage('test_app --silent --force --rm-data');
 	}
 
 	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$appId = $input->getArgument('appid');
 		$silent = $input->getOption('silent');
 		$force = $input->getOption('force');
-		$keep_data = $input->getOption('keep-data');
+		$rmData = $input->getOption('rm-data');
 
 		$exApp = $this->exAppService->getExApp($appId);
 		if ($exApp === null) {
@@ -104,7 +105,7 @@ class Unregister extends Command {
 			} elseif (!$silent) {
 				$output->writeln(sprintf('ExApp %s container successfully removed', $appId));
 			}
-			if (!$keep_data) {
+			if ($rmData) {
 				$volumeName = $this->dockerActions->buildExAppVolumeName($appId);
 				$removeVolumeResult = $this->dockerActions->removeVolume(
 					$this->dockerActions->buildDockerUrl($daemonConfig), $volumeName

--- a/lib/Command/ExApp/Unregister.php
+++ b/lib/Command/ExApp/Unregister.php
@@ -42,7 +42,7 @@ class Unregister extends Command {
 			null,
 			InputOption::VALUE_NONE,
 			'Continue removal even if errors.');
-		$this->addOption('keep-data', null, InputOption::VALUE_NONE, 'Keep ExApp data (volume) [deprecated, data always kept].');
+		$this->addOption('keep-data', null, InputOption::VALUE_NONE, 'Keep ExApp data (volume) [deprecated, data is kept by default].');
 		$this->addOption('rm-data', null, InputOption::VALUE_NONE, 'Remove ExApp data (persistent storage volume).');
 
 		$this->addUsage('test_app');

--- a/tests/test_occ_commands_docker.py
+++ b/tests/test_occ_commands_docker.py
@@ -65,14 +65,14 @@ if __name__ == "__main__":
     r = run("php occ --no-warnings app_api:app:unregister skeleton".split(), stdout=PIPE)
     assert r.returncode
     assert r.stdout.decode("UTF-8"), "Output should be non empty"
-    # testing if "--keep-data" works.
+    # testing if volume is kept by default
     deploy_register()
-    r = run("php occ --no-warnings app_api:app:unregister skeleton --keep-data".split(), stdout=PIPE, check=True)
+    r = run("php occ --no-warnings app_api:app:unregister skeleton".split(), stdout=PIPE, check=True)
     assert r.stdout.decode("UTF-8"), "Output should be non empty"
     run("docker volume inspect nc_app_skeleton_data".split(), check=True)
-    # test if volume will be removed without "--keep-data"
+    # test if volume will be removed with "--rm-data"
     deploy_register()
-    run("php occ --no-warnings app_api:app:unregister skeleton".split(), check=True)
+    run("php occ --no-warnings app_api:app:unregister skeleton --rm-data".split(), check=True)
     r = run("docker volume inspect nc_app_skeleton_data".split())
     assert r.returncode
     # test "--force" option


### PR DESCRIPTION
Do not remove ExApp docker volume by default, deprecate old option `keep-data`, add new `rm-data` to remove ExApp data.