### PR TITLE
feat: add nextcloud url helper info endpoint to get instance base_url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [3.2.0 - 2024-09-09]
+## [3.2.0 - 2024-09-10]
 
 ### Added
 
 - ExAppProxy: added bruteforce protection option for ExApp routes. #368
+- ExAppOCS: added miscellaneous method to get Nextcloud instance base URL. #383
 
 ### Changed
 

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -64,6 +64,7 @@ return [
 		['name' => 'OCSApi#getEnabledState', 'url' => '/ex-app/state', 'verb' => 'GET'],
 
 		// ExApps
+		['name' => 'OCSExApp#getNextcloudUrl', 'url' => '/api/v1/info/nextcloud_url', 'verb' => 'GET'],
 		['name' => 'OCSExApp#getExAppsList', 'url' => '/api/v1/ex-app/{list}', 'verb' => 'GET'],
 		['name' => 'OCSExApp#getExApp', 'url' => '/api/v1/ex-app/info/{appId}', 'verb' => 'GET'],
 

--- a/docs/tech_details/api/exapp.rst
+++ b/docs/tech_details/api/exapp.rst
@@ -59,6 +59,24 @@ Response data
 
 Returns HTTP 200 on success, HTTP 404 - on error.
 
+Get Nextcloud URL
+^^^^^^^^^^^^^^^^^
+
+It might be necessary for ExApp to know (or update) the Nextcloud URL.
+
+OCS endpoint: ``GET /apps/app_api/api/v1/info/nextcloud_url``
+
+Response data
+*************
+
+Returns the base URL of the Nextcloud instance:
+
+.. code-block:: json
+
+	{
+		"base_url": "http(s)://nextcloud.example.com"
+	}
+
 
 Make Requests to ExApps
 ^^^^^^^^^^^^^^^^^^^^^^^

--- a/lib/Controller/OCSExAppController.php
+++ b/lib/Controller/OCSExAppController.php
@@ -14,6 +14,7 @@ use OCP\AppFramework\Http\DataResponse;
 use OCP\AppFramework\OCS\OCSBadRequestException;
 use OCP\AppFramework\OCSController;
 use OCP\IRequest;
+use OCP\IURLGenerator;
 
 class OCSExAppController extends OCSController {
 	protected $request;
@@ -22,6 +23,7 @@ class OCSExAppController extends OCSController {
 		IRequest                       $request,
 		private readonly AppAPIService $service,
 		private readonly ExAppService  $exAppService,
+		private readonly IURLGenerator $urlGenerator,
 	) {
 		parent::__construct(Application::APP_ID, $request);
 
@@ -43,6 +45,13 @@ class OCSExAppController extends OCSController {
 			return new DataResponse([], Http::STATUS_NOT_FOUND);
 		}
 		return new DataResponse($this->exAppService->formatExAppInfo($exApp), Http::STATUS_OK);
+	}
+
+	#[NoCSRFRequired]
+	public function getNextcloudUrl(): DataResponse {
+		return new DataResponse([
+			'base_url' => $this->urlGenerator->getBaseUrl(),
+		], Http::STATUS_OK);
 	}
 
 	/**


### PR DESCRIPTION
Added miscellaneous OCS method to get current Nextcloud instance base_url.

<img width="883" alt="image" src="https://github.com/user-attachments/assets/42b98354-eabd-4fd4-b75b-fed6e49dd627">
